### PR TITLE
Add Auto-Publish script

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - run: yarn install
+      - run: yarn install --ignore-engines --ignore-scripts
 
       - name: Check Bundle Size
         uses: jackyef/bundlewatch-gh-action@0.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - run: yarn install
+      - run: yarn install --ignore-engines --ignore-scripts
 
-      - name: Run Tests
-        run: yarn test:ci
+      - run: yarn test:ci
 
-      - name: Code Cov
-        uses: codecov/codecov-action@v2.1.0
+      - uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - run: yarn install
+      - run: yarn install --ignore-engines --ignore-scripts
 
       - name: Build Docs
         run: yarn docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - run: yarn install
+      - run: yarn install --ignore-engines --ignore-scripts
 
       - name: Run Linters
         run: yarn lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,9 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - name: Build
-        run: yarn build
+      - run: yarn install --ignore-engines --ignore-scripts
+
+      - run: yarn build
 
       # Only publishes if package.json has updated
       - uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
-name: Publish + Release on Version Bump
+name: Publish
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   publish:
@@ -11,26 +10,15 @@ jobs:
       INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'yarn'
 
-      - run: yarn install --ignore-engines --ignore-scripts
+      - name: Build
+        run: yarn build
 
-      - run: yarn build
-
-      # Only publishes if package.json has updated
       - uses: JS-DevTools/npm-publish@v1
         id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create Release
-        if: steps.publish.outputs.type != 'none'
-        uses: softprops/action-gh-release@HEAD
-        with:
-          tag_name: v${{ steps.publish.outputs.version }}
-          append_body: true
-          generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish + Release on Version Bump
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Build
+        run: yarn build
+
+      # Only publishes if package.json has updated
+      - uses: JS-DevTools/npm-publish@v1
+        id: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release
+        if: steps.publish.outputs.type != 'none'
+        uses: softprops/action-gh-release@HEAD
+        with:
+          tag_name: v${{ steps.publish.outputs.version }}
+          append_body: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: justincy/github-action-npm-release@v1.2.0


### PR DESCRIPTION
This adds a two new scripts: `release` and `publish`. 

`release` will look for changes to the package.json and automagically create a release when such an update is pushed to `main`.

`publish` will trigger off of releases and kick off an NPM publish. 