### PR TITLE
Tweak copy in Randsum notation

### DIFF
--- a/RANDSUM_DICE_NOTATION.md
+++ b/RANDSUM_DICE_NOTATION.md
@@ -582,10 +582,11 @@ randsum({
 
 Roll additional dice whenever a die in the pool rolls its maximum value
 
-````markdown
+```markdown
 Roll an additional die every time you roll maximum value of a die
 
 4d20!
+```
 
 In `randsum`:
 

--- a/RANDSUM_DICE_NOTATION.md
+++ b/RANDSUM_DICE_NOTATION.md
@@ -597,4 +597,3 @@ randsum('6d20!')
 randsum(20, { quantity: 6, modifiers: [{ explode: true }] })
 randsum({ sides: 20, quantity: 6, modifiers: [{ explode: true }] })
 ```
-````


### PR DESCRIPTION
fixing a missing closed markdown enclosure