### PR TITLE
Fix faces rolling bug, tweak internal stylings and overloads 

### DIFF
--- a/bin/sanity.js
+++ b/bin/sanity.js
@@ -1,68 +1,45 @@
 import randsum from '../dist/index.module.js'
 
+function times(iterator) {
+  return (callback) => {
+    if (iterator > 0) {
+      callback(iterator)
+      times(iterator - 1)(callback)
+    }
+  }
+}
 console.log('simple')
-console.log(randsum(20))
-console.log(randsum(20))
-console.log(randsum(20))
+const simple = () => console.log(randsum(20))
+times(3)(simple)
 
 console.log('simple detailed')
-console.log(randsum('20', { detailed: true }))
-console.log(randsum('20', { detailed: true }))
-console.log(randsum('20', { detailed: true }))
+const simpleDetailed = () => console.log(randsum('20', { detailed: true }))
+times(3)(simpleDetailed)
 
 console.log('Dice Notation Custom Sides')
-console.log(randsum('20d{++--  }'))
-console.log(randsum('20d{++--  }'))
-console.log(randsum('20d{++--  }'))
+const diceNotationCustomSides = () => console.log(randsum('20d{++--  }'))
+times(3)(diceNotationCustomSides)
 
 console.log('complex options')
-console.log(
-  randsum({
-    quantity: 4,
-    sides: 6,
-    modifiers: [
-      { reroll: { exact: ['2', 1] } },
-      { replace: { from: '6', to: '1' } },
-      { unique: true }
-    ]
-  })
-)
-console.log(
-  randsum({
-    quantity: 4,
-    sides: 6,
-    modifiers: [
-      { reroll: { exact: ['2', 1] } },
-      { replace: { from: '6', to: '1' } },
-      { unique: true }
-    ]
-  })
-)
-console.log(
-  randsum({
-    quantity: 4,
-    sides: 6,
-    modifiers: [
-      { reroll: { exact: ['2', 1] } },
-      { replace: { from: '6', to: '1' } },
-      { unique: true }
-    ]
-  })
-)
+const complexOptions = () =>
+  console.log(
+    randsum({
+      quantity: 4,
+      sides: 6,
+      modifiers: [
+        { reroll: { exact: ['2', 1] } },
+        { replace: { from: '6', to: '1' } },
+        { unique: true }
+      ]
+    })
+  )
+times(3)(complexOptions)
 
 console.log('Complex Notation')
-console.log(
-  randsum(
-    `10d20H2LV{ 1= 2,> 2=6}D{< 2,> 5, 2, 4}C < 2 > 18R{ 5, 2,< 6}3U{ 5}! + 2 - 5 + 3`
+const complexNotation = () =>
+  console.log(
+    randsum(
+      `10d20H2LV{ 1= 2,> 2=6}D{< 2,> 5, 2, 4}C < 2 > 18R{ 5, 2,< 6}3U{ 5}! + 2 - 5 + 3`
+    )
   )
-)
-console.log(
-  randsum(
-    `10d20H2LV{ 1= 2,> 2=6}D{< 2,> 5, 2, 4}C < 2 > 18R{ 5, 2,< 6}3U{ 5}! + 2 - 5 + 3`
-  )
-)
-console.log(
-  randsum(
-    `10d20H2LV{ 1= 2,> 2=6}D{< 2,> 5, 2, 4}C < 2 > 18R{ 5, 2,< 6}3U{ 5}! + 2 - 5 + 3`
-  )
-)
+times(3)(complexNotation)

--- a/src/generateResult/generate-result.test.ts
+++ b/src/generateResult/generate-result.test.ts
@@ -1,4 +1,4 @@
-import { InternalRollParameters, RollResult } from 'types'
+import { InternalRollParameters } from 'types'
 import { generateResult } from './generate-result'
 
 const mockRandomizer = () => 5
@@ -17,21 +17,9 @@ describe('generateResult', () => {
     rollOne: () => 200
   })
 
-  const baseArguments: RollResult['arguments'] = [20, undefined]
-
   describe('when given roll total with no modifiers', () => {
-    test('it returns the arguments provided in the roll result object', () => {
-      expect(
-        generateResult(baseParameters, baseArguments, baseRollGenerator)
-      ).toMatchObject({
-        arguments: baseArguments
-      })
-    })
-
     test('it returns the sum total of the quantity and the roll total', () => {
-      expect(
-        generateResult(baseParameters, baseArguments, baseRollGenerator)
-      ).toMatchObject({
+      expect(generateResult(baseParameters, baseRollGenerator)).toMatchObject({
         total: 10,
         rolls: [1, 2, 3, 4]
       })
@@ -45,7 +33,7 @@ describe('generateResult', () => {
 
       generateResult(
         { ...baseParameters, randomizer: mockRandomizer },
-        baseArguments,
+
         mockRollGenerator
       )
 
@@ -72,7 +60,7 @@ describe('generateResult', () => {
 
     test('it re-quantity non-unique modifiers', () => {
       expect(
-        generateResult(uniqueParameters, baseArguments, uniqueRollGenerator)
+        generateResult(uniqueParameters, uniqueRollGenerator)
       ).toMatchObject({
         total: 206,
         rolls: [1, 200, 2, 3]
@@ -89,7 +77,7 @@ describe('generateResult', () => {
         expect(
           generateResult(
             notUniqueParameters,
-            baseArguments,
+
             uniqueRollGenerator
           )
         ).toMatchObject({
@@ -114,7 +102,7 @@ describe('generateResult', () => {
         expect(() =>
           generateResult(
             overflowParameters,
-            baseArguments,
+
             overflowRollGenerator
           )
         ).toThrow(
@@ -134,7 +122,7 @@ describe('generateResult', () => {
     }
     test('it returns the expected result as a string', () => {
       expect(
-        generateResult(customSidesParameters, baseArguments, baseRollGenerator)
+        generateResult(customSidesParameters, baseRollGenerator)
       ).toMatchObject({
         total: 'r, a, n, d',
         rolls: ['r', 'a', 'n', 'd']
@@ -167,7 +155,7 @@ describe('generateResult', () => {
 
     test('it returns the total without the provided values', () => {
       expect(
-        generateResult(dropParameters, baseArguments, overflowRollGenerator)
+        generateResult(dropParameters, overflowRollGenerator)
       ).toMatchObject({
         total: 17,
         rolls: [4, 6, 7]
@@ -183,9 +171,9 @@ describe('generateResult', () => {
       }
 
       test('it returns the total with all values replaced according to the provided rules', () => {
-        expect(
-          generateResult(dropParameters, baseArguments, baseRollGenerator)
-        ).toMatchObject({ total: 11, rolls: [2, 2, 3, 4] })
+        expect(generateResult(dropParameters, baseRollGenerator)).toMatchObject(
+          { total: 11, rolls: [2, 2, 3, 4] }
+        )
       })
     })
 
@@ -203,9 +191,9 @@ describe('generateResult', () => {
       }
 
       test('it returns the total with all values replaced according to the provided rules', () => {
-        expect(
-          generateResult(dropParameters, baseArguments, baseRollGenerator)
-        ).toMatchObject({ total: 13, rolls: [2, 2, 3, 6] })
+        expect(generateResult(dropParameters, baseRollGenerator)).toMatchObject(
+          { total: 13, rolls: [2, 2, 3, 6] }
+        )
       })
     })
   })
@@ -224,7 +212,7 @@ describe('generateResult', () => {
 
     test('it returns the total with all values matching the queries rerolled', () => {
       expect(
-        generateResult(explodeParameters, baseArguments, explodeRollGenerator)
+        generateResult(explodeParameters, explodeRollGenerator)
       ).toMatchObject({
         total: 212,
         rolls: [1, 2, 3, 6, 200]
@@ -245,7 +233,7 @@ describe('generateResult', () => {
 
       test('it stops at 99 rerolls and returns the total with all values matching the queries rerolled', () => {
         expect(
-          generateResult(rerollParameters, baseArguments, baseRollGenerator)
+          generateResult(rerollParameters, baseRollGenerator)
         ).toMatchObject({
           total: 206,
           rolls: [1, 2, 3, 200]
@@ -261,7 +249,7 @@ describe('generateResult', () => {
 
       test('it returns the total with all values matching the queries rerolled', () => {
         expect(
-          generateResult(rerollParameters, baseArguments, baseRollGenerator)
+          generateResult(rerollParameters, baseRollGenerator)
         ).toMatchObject({
           total: 404,
           rolls: [1, 200, 3, 200]
@@ -277,7 +265,7 @@ describe('generateResult', () => {
 
       test('it returns the total with all values matching the queries rerolled', () => {
         expect(
-          generateResult(rerollParameters, baseArguments, baseRollGenerator)
+          generateResult(rerollParameters, baseRollGenerator)
         ).toMatchObject({
           total: 406,
           rolls: [200, 2, 200, 4]
@@ -293,9 +281,7 @@ describe('generateResult', () => {
     }
 
     test('it returns the total with all values greaterThan greaterThan and lessThan lessThan replaced with their respective comparitor and the roll total', () => {
-      expect(
-        generateResult(dropParameters, baseArguments, baseRollGenerator)
-      ).toMatchObject({
+      expect(generateResult(dropParameters, baseRollGenerator)).toMatchObject({
         total: 10,
         rolls: [2, 2, 3, 3]
       })
@@ -309,9 +295,7 @@ describe('generateResult', () => {
     }
 
     test('it returns the total plus the "plus" modifier, and the roll total', () => {
-      expect(
-        generateResult(dropParameters, baseArguments, baseRollGenerator)
-      ).toMatchObject({
+      expect(generateResult(dropParameters, baseRollGenerator)).toMatchObject({
         total: 12,
         rolls: [1, 2, 3, 4]
       })
@@ -325,9 +309,7 @@ describe('generateResult', () => {
     }
 
     test('it returns the total minust the "minus" modifier, and the roll total', () => {
-      expect(
-        generateResult(dropParameters, baseArguments, baseRollGenerator)
-      ).toMatchObject({
+      expect(generateResult(dropParameters, baseRollGenerator)).toMatchObject({
         total: 8,
         rolls: [1, 2, 3, 4]
       })

--- a/src/generateResult/generate-result.ts
+++ b/src/generateResult/generate-result.ts
@@ -29,30 +29,15 @@ export function generateResult(
     const [key] = Object.keys(modifier)
     const [value] = Object.values(modifier)
 
-    if (key === 'reroll') {
-      rolls = applyReroll(rolls, value, rollOne)
-    }
-    if (key === 'unique') {
-      rolls = applyUnique(rolls, { sides, quantity, unique: value }, rollOne)
-    }
-    if (key === 'replace') {
-      rolls = applyReplace(rolls, value)
-    }
-    if (key === 'cap') {
-      rolls = rolls.map(applySingleCap(value))
-    }
-    if (key === 'drop') {
-      rolls = applyDrop(rolls, value)
-    }
-    if (key === 'explode') {
-      rolls = applyExplode(rolls, { sides }, rollOne)
-    }
-    if (key === 'plus') {
-      simpleMathModifier += Number(value)
-    }
-    if (key === 'minus') {
-      simpleMathModifier -= Math.abs(Number(value))
-    }
+    key === 'reroll' && (rolls = applyReroll(rolls, value, rollOne))
+    key === 'unique' &&
+      (rolls = applyUnique(rolls, { sides, quantity, unique: value }, rollOne))
+    key === 'replace' && (rolls = applyReplace(rolls, value))
+    key === 'cap' && (rolls = rolls.map(applySingleCap(value)))
+    key === 'drop' && (rolls = applyDrop(rolls, value))
+    key === 'explode' && (rolls = applyExplode(rolls, { sides }, rollOne))
+    key === 'plus' && (simpleMathModifier += Number(value))
+    key === 'minus' && (simpleMathModifier -= Math.abs(Number(value)))
   }
 
   return {

--- a/src/generateResult/generate-result.ts
+++ b/src/generateResult/generate-result.ts
@@ -17,9 +17,10 @@ import { generateTotalAndRolls } from './generate-total-and-rolls'
 
 export function generateResult(
   { sides, quantity, modifiers, randomizer, faces }: InternalRollParameters,
-  randsumArguments: RollResult['arguments'],
   rollGenerator = generateRolls
-): RollResult<StandardDie> | RollResult<CustomSidesDie> {
+):
+  | Omit<RollResult<StandardDie>, 'arguments'>
+  | Omit<RollResult<CustomSidesDie>, 'arguments'> {
   const { rollOne, initialRolls } = rollGenerator(sides, quantity, randomizer)
 
   let rolls = [...initialRolls]
@@ -42,7 +43,6 @@ export function generateResult(
 
   return {
     ...generateTotalAndRolls({ faces, rolls, simpleMathModifier }),
-    arguments: randsumArguments,
     rollParameters: {
       sides,
       quantity,

--- a/src/generateResult/generate-total-and-rolls.ts
+++ b/src/generateResult/generate-total-and-rolls.ts
@@ -24,6 +24,6 @@ export function generateTotalAndRolls({
     }
   }
 
-  const newRolls = rolls.map((roll) => faces[roll - 1])
+  const newRolls = rolls.map((roll) => faces[roll - 1] || ' ')
   return { total: newRolls.join(', '), rolls: newRolls }
 }

--- a/src/parseArguments/parseNotation/parse-notation.ts
+++ b/src/parseArguments/parseNotation/parse-notation.ts
@@ -34,66 +34,56 @@ export function parseNotation(
         break
       }
     }
-    if (key === 'dropHighMatch') {
-      rollParameters = {
+    key === 'dropHighMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseDropHighNotation(value)]
-      }
-    }
-    if (key === 'dropLowMatch') {
-      rollParameters = {
+      })
+    key === 'dropLowMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseDropLowNotation(value)]
-      }
-    }
-    if (key === 'dropConstraintsMatch') {
-      rollParameters = {
+      })
+    key === 'dropConstraintsMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseDropConstraintsNotation(value)]
-      }
-    }
-    if (key === 'explodeMatch') {
-      rollParameters = {
+      })
+    key === 'explodeMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, { explode: Boolean(value) }]
-      }
-    }
-    if (key === 'uniqueMatch') {
-      rollParameters = {
+      })
+    key === 'uniqueMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseUniqueNotation(value)]
-      }
-    }
-    if (key === 'replaceMatch') {
-      rollParameters = {
+      })
+    key === 'replaceMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseReplaceNotation(value)]
-      }
-    }
-    if (key === 'rerollMatch') {
-      rollParameters = {
+      })
+    key === 'rerollMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseRerollNotation(value)]
-      }
-    }
-    if (key === 'capMatch') {
-      rollParameters = {
+      })
+    key === 'capMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, parseCapNotation(value)]
-      }
-    }
-    if (key === 'plusMatch') {
-      rollParameters = {
+      })
+    key === 'plusMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, { plus: Number(value.split('+')[1]) }]
-      }
-    }
-    if (key === 'minusMatch') {
-      rollParameters = {
+      })
+    key === 'minusMatch' &&
+      (rollParameters = {
         ...restParameters,
         modifiers: [...modifiers, { minus: Number(value.split('-')[1]) }]
-      }
-    }
+      })
   }
 
   return rollParameters

--- a/src/randsum.ts
+++ b/src/randsum.ts
@@ -11,7 +11,8 @@ import {
   DieType,
   StandardDie,
   Detailed,
-  RandsumArguments
+  RandsumArguments,
+  BaseRollResult
 } from './types'
 
 // Sides Arguments
@@ -72,7 +73,14 @@ export function randsum(
     primeArgument,
     randsumOptions
   )
-  const result = generateResult(parameters, [primeArgument, randsumOptions])
+  const passedArguments: BaseRollResult['arguments'] = [
+    primeArgument,
+    randsumOptions
+  ]
+  const result: RollResult<StandardDie> | RollResult<CustomSidesDie> = {
+    ...generateResult(parameters),
+    arguments: passedArguments
+  }
 
   return detailed ? result : result.total
 }

--- a/src/randsum.ts
+++ b/src/randsum.ts
@@ -11,7 +11,6 @@ import {
   StandardDie,
   Detailed,
   RandsumArguments,
-  BaseRollResult,
   Simple
 } from './types'
 

--- a/src/randsum.ts
+++ b/src/randsum.ts
@@ -8,61 +8,63 @@ import {
   RollResult,
   UserOptions,
   CustomSidesDie,
-  DieType,
   StandardDie,
   Detailed,
   RandsumArguments,
-  BaseRollResult
+  BaseRollResult,
+  Simple
 } from './types'
 
 // Sides Arguments
-export function randsum(sides: NumberString): number
 export function randsum(
   sides: NumberString,
-  randsumOptions: SecondaryRandsumOptions
+  randsumOptions?: SecondaryRandsumOptions<StandardDie, Simple>
 ): number
-export function randsum<N extends StandardDie>(
-  sides: NumberString,
-  randsumOptions: SecondaryRandsumOptions<N, Detailed>
-): RollResult<N>
 export function randsum(
   sides: NumberString,
-  randsumOptions: SecondaryRandsumOptions<CustomSidesDie>
+  randsumOptions: SecondaryRandsumOptions<CustomSidesDie, Simple>
 ): string
-export function randsum<N extends CustomSidesDie>(
+export function randsum(
   sides: NumberString,
-  randsumOptions: SecondaryRandsumOptions<N, Detailed>
-): RollResult<N>
+  randsumOptions: SecondaryRandsumOptions<StandardDie, Detailed>
+): RollResult<StandardDie>
+export function randsum(
+  sides: NumberString,
+  randsumOptions: SecondaryRandsumOptions<CustomSidesDie, Detailed>
+): RollResult<CustomSidesDie>
 
 // Notation arguments
-export function randsum(notation: DiceNotation): number
-export function randsum(notation: DiceNotation<CustomSidesDie>): string
 export function randsum(
-  notation: DiceNotation,
-  userOptions: UserOptions
+  notation: DiceNotation<StandardDie>,
+  userOptions?: UserOptions<Simple>
 ): number
-export function randsum<N extends DieType = StandardDie>(
-  notation: DiceNotation,
-  userOptions: UserOptions<Detailed>
-): RollResult<N>
 export function randsum(
   notation: DiceNotation<CustomSidesDie>,
-  userOptions: UserOptions
+  userOptions?: UserOptions<Simple>
 ): string
-export function randsum<N extends CustomSidesDie>(
-  notation: DiceNotation<N>,
+export function randsum(
+  notation: DiceNotation<StandardDie>,
   userOptions: UserOptions<Detailed>
-): RollResult<N>
+): RollResult<StandardDie>
+
+export function randsum(
+  notation: DiceNotation<CustomSidesDie>,
+  userOptions: UserOptions<Detailed>
+): RollResult<CustomSidesDie>
 
 // Option argument
-export function randsum(rollOptions: RandsumOptions<StandardDie>): number
-export function randsum(rollOptions: RandsumOptions<CustomSidesDie>): string
-export function randsum<N extends StandardDie>(
-  rollOptions: RandsumOptions<N, Detailed>
-): RollResult<N>
-export function randsum<N extends DieType = CustomSidesDie>(
-  rollOptions: RandsumOptions<N, Detailed>
-): RollResult<N>
+export function randsum(
+  rollOptions: RandsumOptions<StandardDie, Simple>
+): number
+export function randsum(
+  rollOptions: RandsumOptions<CustomSidesDie, Simple>
+): string
+export function randsum(
+  rollOptions: RandsumOptions<StandardDie, Detailed>
+): RollResult<StandardDie>
+export function randsum(
+  rollOptions: RandsumOptions<CustomSidesDie, Detailed>
+): RollResult<CustomSidesDie>
 
 // Implementation
 export function randsum(

--- a/src/randsum.ts
+++ b/src/randsum.ts
@@ -69,19 +69,16 @@ export function randsum(
 // Implementation
 export function randsum(
   primeArgument: RandsumArguments['primeArgument'],
-  randsumOptions?: RandsumArguments['secondArgument']
+  secondArgument?: RandsumArguments['secondArgument']
 ): RollResult<StandardDie> | RollResult<CustomSidesDie> | number | string {
   const { detailed, ...parameters } = parseArguments(
     primeArgument,
-    randsumOptions
+    secondArgument
   )
-  const passedArguments: BaseRollResult['arguments'] = [
-    primeArgument,
-    randsumOptions
-  ]
+
   const result: RollResult<StandardDie> | RollResult<CustomSidesDie> = {
     ...generateResult(parameters),
-    arguments: passedArguments
+    arguments: [primeArgument, secondArgument]
   }
 
   return detailed ? result : result.total

--- a/src/types/arguments.ts
+++ b/src/types/arguments.ts
@@ -8,10 +8,3 @@ export type RandsumArguments<
   primeArgument: RandsumOptions<N, D> | DiceNotation<N> | NumberString
   secondArgument?: SecondaryRandsumOptions<N, D> | UserOptions<D>
 }
-
-export type AllArgumentTypes<
-  N extends DieType = DieType,
-  D extends DetailedType = DetailedType
-> =
-  | RandsumArguments<N, D>['primeArgument']
-  | RandsumArguments<N, D>['secondArgument']

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -9,7 +9,7 @@ import {
 } from './primitives'
 import { Modifier } from './modifiers'
 
-export interface UserOptions<D extends DetailedType = false | never> {
+export interface UserOptions<D extends DetailedType> {
   detailed?: D
   randomizer?: Randomizer
 }
@@ -29,8 +29,8 @@ export type CustomSidesRandsumOptions<D extends DetailedType> = Omit<
   sides: CustomSides
 }
 export type RandsumOptions<
-  N extends DieType = StandardDie,
-  D extends DetailedType = false | never
+  N extends DieType,
+  D extends DetailedType
 > = N extends StandardDie
   ? StandardRandsumOptions<D>
   : CustomSidesRandsumOptions<D>
@@ -45,8 +45,8 @@ export type SecondaryCustomSidesRandsumOptions<D extends DetailedType> = Omit<
 > & { faces: CustomSides }
 
 export type SecondaryRandsumOptions<
-  N extends DieType = StandardDie,
-  D extends DetailedType = false | never
+  N extends DieType,
+  D extends DetailedType
 > = N extends StandardDie
   ? SecondaryStandardRandsumOptions<D>
   : SecondaryCustomSidesRandsumOptions<D>

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -11,10 +11,9 @@ export type DiceNotationWithCustomSides = `${number}${
   | 'd'
   | 'D'}${CustomDiceSidesNotation}`
 
-export type DiceNotation<N extends DieType = StandardDie> =
-  N extends StandardDie
-    ? DiceNotationWithNumericSides
-    : DiceNotationWithCustomSides
+export type DiceNotation<N extends DieType = DieType> = N extends StandardDie
+  ? DiceNotationWithNumericSides
+  : DiceNotationWithCustomSides
 
 export type NumberStringArgument = number | 'inclusive'
 
@@ -29,4 +28,4 @@ export type CustomSides = Array<number | string>
 
 export type Detailed = true
 export type Simple = false
-export type DetailedType = Detailed | Simple | never
+export type DetailedType = Detailed | Simple

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -2,13 +2,14 @@ import { RandsumArguments } from './arguments'
 import { RollParameters } from './parameters'
 import { CustomSides, DieType, StandardDie } from './primitives'
 
-type BaseRollResult = {
+export type BaseRollResult = {
   rollParameters: RollParameters
   arguments: [
     RandsumArguments['primeArgument'],
     RandsumArguments['secondArgument']
   ]
 }
+
 type StandardRollResult = BaseRollResult & {
   total: number
   rolls: number[]

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -20,6 +20,6 @@ type CustomSidesRollResult = BaseRollResult & {
   rolls: CustomSides
 }
 
-export type RollResult<N extends DieType = DieType> = N extends StandardDie
+export type RollResult<N extends DieType> = N extends StandardDie
   ? StandardRollResult
   : CustomSidesRollResult


### PR DESCRIPTION
It was possible, while giving a numeric first argument and an options second argument containg `faces`, where the `faces` array was less than the total. The intention was to make these roll as blanks (` `) - and they did appear that way in the totals. However, in the `rolls` we can see they are `undefined`, so this PR squashes it. 

It also overhauls the default types, moves `arguments` out of `generateResult`, moves a few files around, bada-bing-bada-boom, that's showbiz baby. 