### PR TITLE
Bump local development version of node, slide CI up one scale. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['14.x', '16.x', '18.x']
+        node: [ '16.x', '18.x', '20.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 18.0.0
+nodejs 20.2.0

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "url": "https://github.com/alxjrvs/randsum.git"
   },
   "sideEffects": false,
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "analyze": "size-limit",
     "build": "yarn clean && rollup --bundleConfigAsCjs -c ./scripts/build.js",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "url": "https://github.com/alxjrvs/randsum.git"
   },
   "sideEffects": false,
-  "engines": {
-    "node": ">=12.13"
-  },
   "scripts": {
     "analyze": "size-limit",
     "build": "yarn clean && rollup --bundleConfigAsCjs -c ./scripts/build.js",


### PR DESCRIPTION
One of our ESlint plugins no longer supports Node 14, which gave me the push to be a little more intentional about the node version and support. 

This pr: 
 - fixes our engine version to `>= 16`
 - fixes local node version to current (20.2) 
 - removes `14.x` from testing matrix and adds `20.x`