### PR TITLE
Fix Replace Bug (4.6.1) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "randsum",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "private": false,
   "author": "Alex Jarvis",
   "icon": "https://raw.githubusercontent.com/RANDSUM/randsum-ts/main/icon.webp",

--- a/src/matchPattern.ts
+++ b/src/matchPattern.ts
@@ -5,7 +5,7 @@ export const dropConstraintsPattern = /[Dd]{([<>]?\d+,)*([<>]?\d+)}/g
 export const explodePattern = /!/g
 export const uniquePattern = /[Uu]({(\d+,)*(\d+)})?/g
 export const replacePattern = /[Vv]{([<>]?\d+=?\d+,)*([<>]?\d+=?\d+)}/g
-export const rerollPattern = /[Rr]{([<>]?\d,)*([<>]?\d)}\d*/g
+export const rerollPattern = /[Rr]{([<>]?\d+,)*([<>]?\d+)}\d*/g
 export const capPattern = /[Cc]{([<>]?\d+,)*([<>]?\d+)}/g
 export const plusPattern = /\+\d+/g
 export const minusPattern = /-\d+/g

--- a/tests/parseRollArguments.test.ts
+++ b/tests/parseRollArguments.test.ts
@@ -419,7 +419,7 @@ describe('parseRollArguments', () => {
     })
 
     describe('given a notation that contains a reroll modifier', () => {
-      const argument: DiceNotation = `${coreTestString}R{5,<6,>2}3`
+      const argument: DiceNotation = `${coreTestString}R{5,20,<6,>2}3`
 
       test('returns a RollParameter matching the notation', () => {
         const params = parseRollArguments(argument)
@@ -431,7 +431,7 @@ describe('parseRollArguments', () => {
             ...coreRollParameters,
             modifiers: {
               reroll: {
-                exact: [5],
+                exact: [5, 20],
                 lessThan: 6,
                 greaterThan: 2,
                 maxReroll: 3
@@ -439,10 +439,10 @@ describe('parseRollArguments', () => {
             }
           },
           die: new StandardDie(coreRollParameters.sides),
-          notation: '4d6R{5,>2,<6}3',
+          notation: '4d6R{5,20,>2,<6}3',
           description: [
             'Roll 4 6-sided dice',
-            'Reroll [5], greater than [2] and less than [6] (up to 3 times)'
+            'Reroll [5] and [20], greater than [2] and less than [6] (up to 3 times)'
           ]
         })
       })


### PR DESCRIPTION
Replace now can take explicit numbers greater than 9. D'oh. 