### PR TITLE
Remove Non-Erasable Syntax

### DIFF
--- a/src/dice/D.ts
+++ b/src/dice/D.ts
@@ -2,7 +2,9 @@ import { RollConfig } from '~src/types'
 import { coreRandom } from '~src/utils/coreRandom'
 
 export class D {
-  constructor(public sides: number) {
+  public sides: number
+
+  constructor(sides: number) {
     this.sides = sides
   }
 

--- a/src/faces/customFacesD.ts
+++ b/src/faces/customFacesD.ts
@@ -5,8 +5,9 @@ import { D } from '~dice'
 export class CustomFacesD {
   public sides: number
   private coreDie: D
+  public faces: string[]
 
-  constructor(public faces: string[]) {
+  constructor(faces: string[]) {
     this.sides = faces.length
     this.faces = faces
     this.coreDie = new D(this.sides)


### PR DESCRIPTION
Following the pattern of the Erasable Syntax Only flag, this PR removes all non-erasable syntax so that these files might be one day directly run in Node! 