### PR TITLE
test: conformance hardening — vector tests, cap fix, forms validation, $id

### DIFF
--- a/apps/rdn/conformance-gen.ts
+++ b/apps/rdn/conformance-gen.ts
@@ -26,6 +26,7 @@ function stableVector(v: object): object {
 }
 
 const output = {
+  $id: CONFORMANCE_FILE.$id,
   specVersion: CONFORMANCE_FILE.specVersion,
   generatedFrom: CONFORMANCE_FILE.generatedFrom,
   conformanceLevels: CONFORMANCE_FILE.conformanceLevels,

--- a/apps/rdn/conformance-gen.ts
+++ b/apps/rdn/conformance-gen.ts
@@ -59,4 +59,4 @@ if (proc.exitCode !== 0) {
 }
 
 await Bun.write(outPath, new TextDecoder().decode(proc.stdout))
-console.log(`Written: ${outPath.pathname}`)
+console.warn(`Written: ${outPath.pathname}`)

--- a/apps/rdn/public/conformance/v0.9.0.json
+++ b/apps/rdn/public/conformance/v0.9.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://notation.randsum.dev/conformance/v0.9.0.json",
   "specVersion": "0.9.0",
   "generatedFrom": "apps/rdn/src/conformance/vectors.ts",
   "conformanceLevels": {

--- a/apps/rdn/src/conformance/types.ts
+++ b/apps/rdn/src/conformance/types.ts
@@ -59,6 +59,7 @@ export interface ConformanceVector {
 
 /** Top-level shape of the conformance JSON file. */
 export interface ConformanceFile {
+  readonly $id?: string
   readonly specVersion: string
   readonly generatedFrom: string
   readonly conformanceLevels: {

--- a/apps/rdn/src/conformance/vectors.ts
+++ b/apps/rdn/src/conformance/vectors.ts
@@ -1,6 +1,7 @@
 import type { ConformanceFile } from './types'
 
 export const CONFORMANCE_FILE: ConformanceFile = {
+  $id: 'https://notation.randsum.dev/conformance/v0.9.0.json',
   specVersion: '0.9.0',
   generatedFrom: 'apps/rdn/src/conformance/vectors.ts',
   conformanceLevels: {

--- a/packages/roller/__tests__/docs/formsValidation.test.ts
+++ b/packages/roller/__tests__/docs/formsValidation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+import { NOTATION_DOCS } from '../../src/docs'
+import { isDiceNotation } from '../../src/notation/isDiceNotation'
+
+/**
+ * Substitute template variables in a forms[].notation string with real values
+ * so the result is executable dice notation.
+ *
+ * Substitution rules (applied in order):
+ *  - `({..})` or `({...})` — optional exception list (Unique); drop the whole optional block
+ *  - `(n)` or `(d)`        — literal optional count; substitute with 1
+ *  - `{condition}`         — comparison condition placeholder; substitute with `{<3}`
+ *  - `V{...}`              — Replace notation; needs n=y pairs; substitute V{...} → V{1=2}
+ *  - `{N1,N2,...}`         — die-size sequence; substitute with `{4,6,8}`
+ *  - `{n,b}`               — success/botch pair; substitute with `{7,1}`
+ *  - `{n}`                 — single numeric threshold; substitute with `{7}`
+ *  - `{N}`                 — single die size; substitute with `{6}`
+ *  - `{a,b,c,...}`         — custom face list; substitute with `{1,2,3}`
+ *  - `{..}` / `{...}`      — catch-all condition block; substitute with `{1}`
+ *  - bare `N` (uppercase)  — die-size placeholder; substitute with `6`
+ *  - bare `n` (lowercase)  — count placeholder; substitute with `1`
+ *  - leading `x`           — quantity prefix; substitute with `4`
+ */
+function substituteTemplateVars(notation: string): string {
+  return (
+    notation
+      // U({..}) / U({...}) — optional exception list; drop entire optional block
+      .replace(/\(\{\.{2,3}\}\)/g, '')
+      // (n) or (d) → 1
+      .replace(/\([nd]\)/g, '1')
+      // {condition} → {<3}
+      .replace(/\{condition\}/g, '{<3}')
+      // V{...} — Replace notation needs n=y pairs
+      .replace(/V\{\.{2,3}\}/, 'V{1=2}')
+      // {N1,N2,...} → {4,6,8}
+      .replace(/\{N1,N2,\.\.\.\}/g, '{4,6,8}')
+      // {n,b} (success, botch thresholds) → {7,1}
+      .replace(/\{n,b\}/g, '{7,1}')
+      // {n} single threshold → {7}
+      .replace(/\{n\}/g, '{7}')
+      // {N} single die size → {6}
+      .replace(/\{N\}/g, '{6}')
+      // {a,b,c,...} custom faces → {1,2,3}
+      .replace(/\{a,b,c,\.\.\.\}/g, '{1,2,3}')
+      // {..} or {...} catch-all condition → {1}
+      .replace(/\{\.{2,3}\}/g, '{1}')
+      // bare N at end of string → 6
+      .replace(/N$/g, '6')
+      // bare N before a non-brace character (e.g. xDDN → xDD6)
+      .replace(/N(?=[^}]|$)/g, '6')
+      // bare n → 1 (lowercase n as count placeholder)
+      .replace(/n/g, '1')
+      // leading x → 4 (quantity prefix, e.g. xDN → 4D6)
+      .replace(/^x/, '4')
+  )
+}
+
+/**
+ * True if the substituted notation already contains a die core, so we should
+ * NOT prepend a default die prefix.
+ */
+const hasCore = (s: string): boolean =>
+  /\d*[dD]\d+/.test(s) ||
+  /\d*[dD]%/.test(s) ||
+  /\d*[dD][fF]/.test(s) ||
+  /\d*[zZ]\d+/.test(s) ||
+  /\d*[gG]\d+/.test(s) ||
+  /\d*[dD]{2}\d+/.test(s) ||
+  /\d*[dD]\{[^}]+\}/.test(s)
+
+const DIE_PREFIX = '4d6'
+
+describe('NotationDoc.forms[].notation — live parser conformance', () => {
+  for (const [key, doc] of Object.entries(NOTATION_DOCS)) {
+    describe(`${doc.title} (${key})`, () => {
+      for (const form of doc.forms) {
+        test(`form "${form.notation}" parses as valid dice notation after substitution`, () => {
+          const substituted = substituteTemplateVars(form.notation)
+          const candidate = hasCore(substituted) ? substituted : `${DIE_PREFIX}${substituted}`
+
+          expect(isDiceNotation(candidate)).toBe(true)
+        })
+      }
+    })
+  }
+})

--- a/packages/roller/__tests__/docs/rosettaStone.test.ts
+++ b/packages/roller/__tests__/docs/rosettaStone.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { NOTATION_DOCS } from '../../src/docs'
 import { roll } from '../../src/roll'
 import { isDiceNotation } from '../../src/notation/isDiceNotation'
+import { notationToOptions } from '../../src/notation/parse/notationToOptions'
 
 /**
  * Detect whether a notation string is a full rollable expression (e.g. "3d6!")
@@ -34,6 +35,22 @@ describe('Rosetta Stone — notation examples', () => {
           expect(result.rolls.length).toBeGreaterThanOrEqual(1)
           expect(typeof result.total).toBe('number')
         })
+
+        test(`notation "${example.notation}" result has expected dice count`, () => {
+          const parsed = notationToOptions(example.notation)
+          const firstParsed = parsed[0]
+          if (firstParsed === undefined) return
+
+          const expectedQuantity = firstParsed.quantity ?? 1
+          const result = roll(example.notation)
+          const firstRoll = result.rolls[0]
+          if (firstRoll === undefined) return
+
+          // Geometric dice roll until 1 — initialRolls.length is variable by design
+          if (firstRoll.parameters.geometric) return
+
+          expect(firstRoll.initialRolls.length).toBe(expectedQuantity)
+        })
       }
     })
   }
@@ -64,6 +81,24 @@ describe('Rosetta Stone — options examples', () => {
           expect(result.rolls.length).toBeGreaterThanOrEqual(1)
           expect(typeof result.total).toBe('number')
         })
+
+        test(`options "${example.description}" has correct quantity of dice`, () => {
+          const expectedQuantity = example.options!.quantity ?? 1
+          const result = roll(example.options!)
+          const firstRoll = result.rolls[0]
+          if (firstRoll === undefined) return
+
+          expect(firstRoll.initialRolls.length).toBe(expectedQuantity)
+        })
+
+        if (isFullNotation(example.notation)) {
+          test(`notation "${example.notation}" and options "${example.description}" produce same pool count`, () => {
+            const notationResult = roll(example.notation)
+            const optionsResult = roll(example.options!)
+
+            expect(notationResult.rolls.length).toBe(optionsResult.rolls.length)
+          })
+        }
       }
     })
   }

--- a/packages/roller/__tests__/docs/rosettaStone.test.ts
+++ b/packages/roller/__tests__/docs/rosettaStone.test.ts
@@ -17,15 +17,6 @@ const isFullNotation = (s: string): boolean =>
   /^\d*[dD]{2}\d+$/.test(s) ||
   /^\d*[dD]\{[^}]+\}$/.test(s)
 
-/**
- * Known options examples that fail due to validation bugs (not doc bugs).
- * Cap's "Clamp rolls to [3, 18]" uses { lessThan: 3, greaterThan: 18 } which is
- * semantically correct for cap (floor/ceiling), but validateComparisonOptions
- * rejects it as an impossible range. The equivalent notation "4d20C{<3,>18}"
- * works fine because it bypasses validation.
- */
-const KNOWN_OPTIONS_FAILURES: ReadonlySet<string> = new Set(['Clamp rolls to [3, 18]'])
-
 describe('Rosetta Stone — notation examples', () => {
   for (const [, doc] of Object.entries(NOTATION_DOCS)) {
     describe(doc.title, () => {
@@ -48,16 +39,25 @@ describe('Rosetta Stone — notation examples', () => {
   }
 })
 
+describe('Cap — floor/ceiling clamp range (S3 regression)', () => {
+  test('cap { lessThan: 3, greaterThan: 18 } validates and rolls without throwing', () => {
+    expect(() => {
+      const result = roll({
+        sides: 20,
+        quantity: 4,
+        modifiers: { cap: { lessThan: 3, greaterThan: 18 } }
+      })
+      expect(result.rolls.length).toBeGreaterThanOrEqual(1)
+      expect(typeof result.total).toBe('number')
+    }).not.toThrow()
+  })
+})
+
 describe('Rosetta Stone — options examples', () => {
   for (const [, doc] of Object.entries(NOTATION_DOCS)) {
     describe(doc.title, () => {
       for (const example of doc.examples) {
         if (example.options === undefined) continue
-
-        if (KNOWN_OPTIONS_FAILURES.has(example.description)) {
-          test.todo(`options "${example.description}" — known validation bug (cap clamp range)`)
-          continue
-        }
 
         test(`options "${example.description}" is rollable`, () => {
           const result = roll(example.options!)

--- a/packages/roller/__tests__/roll/edgeCases.test.ts
+++ b/packages/roller/__tests__/roll/edgeCases.test.ts
@@ -85,24 +85,24 @@ describe('edge cases', () => {
       )
     })
 
-    test('cap with invalid range throws modifier error', () => {
+    test('cap with floor/ceiling range clamps values without throwing', () => {
       expect(() =>
         roll({
           sides: 20,
           quantity: 1,
           modifiers: { cap: { lessThan: 3, greaterThan: 10 } }
         })
-      ).toThrow(ModifierError)
+      ).not.toThrow()
     })
 
-    test('cap with mutually exclusive gt/lt conditions throws modifier error', () => {
+    test('cap with reversed gt/lt clamp range clamps values without throwing', () => {
       expect(() =>
         roll({
           sides: 6,
           quantity: 3,
           modifiers: { cap: { greaterThan: 10, lessThan: 3 } }
         })
-      ).toThrow(ModifierError)
+      ).not.toThrow()
     })
 
     test('reroll with impossible gte/lte conditions throws modifier error', () => {

--- a/packages/roller/__tests__/spec/conformance-vectors.test.ts
+++ b/packages/roller/__tests__/spec/conformance-vectors.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+import { roll } from '../../src/roll'
+import { createQueueRandom } from '../../test-utils/src/queueRandom'
+import { CONFORMANCE_FILE } from '../../../../apps/rdn/src/conformance/vectors'
+
+/**
+ * Conformance Vector Test Suite
+ *
+ * Runs the 48 conformance vectors from the RANDSUM Dice Notation spec against roll().
+ * Each non-error, non-indeterminate vector uses createQueueRandom to produce
+ * deterministic results that should match expectedPool and expectedTotal.
+ *
+ * Skipped vectors and reasons:
+ * - Draw die (DDN): Fisher-Yates shuffle in drawWithoutReplacement cannot be seeded
+ *   via createQueueRandom's linear (v-1)/sides mapping.
+ * - Custom string faces (d{fire,ice,lightning}): expectedPool contains strings;
+ *   createQueueRandom only handles numeric faces.
+ * - Null expectedPool/expectedTotal: indeterminate result per spec.
+ *
+ * Known conformance gaps (marked .todo):
+ * - Vector 2 (d20): roller rejects bare `dN` notation (requires leading quantity digit)
+ * - Vector 39 (3d6!s{4,6,8}): spec uses {values} as trigger set for sequence start;
+ *   roller uses them as die sizes in a step-through sequence — semantics mismatch
+ * - Vector 47 (5d10S{7}F{3}): spec mandates rejection of multiple Count modifiers;
+ *   roller silently accepts and applies the last one
+ */
+
+/**
+ * Convert a numeric face value to the 1-based index used by createQueueRandom
+ * for numericFaces-based dice (Fate, zero-bias).
+ *
+ * The roller maps rng() via: numericFaces[Math.floor(rng() * numericFaces.length)]
+ * createQueueRandom maps value v via: rng() = (v - 1) / sides
+ * So to hit index i: pass (i + 1) and use sides = numericFaces.length
+ */
+function faceValueToQueueIndex(faceValue: number, faces: readonly number[]): number {
+  const idx = faces.indexOf(faceValue)
+  if (idx === -1) throw new Error(`Face value ${faceValue} not found in faces [${faces.join(',')}]`)
+  return idx + 1
+}
+
+// Face arrays for special dice
+const FATE_FACES = [-1, 0, 1] as const
+const FATE_2_FACES = [-2, -1, 0, 1, 2] as const
+
+// Known conformance gaps: vector ids that cannot pass due to roller behavior mismatches
+// These are marked .todo() rather than skipped to surface them as known failures.
+const KNOWN_CONFORMANCE_GAPS: Record<number, string> = {
+  2: 'roller rejects bare `dN` notation without a leading quantity digit (spec §4.1 requires it be valid)',
+  39: 'spec interprets !s{4,6,8} as trigger values for sequence; roller uses them as die sizes',
+  47: 'spec requires rejection of multiple Count modifiers (S{7}F{3}); roller silently accepts'
+}
+
+describe('Conformance Vectors', () => {
+  for (const vector of CONFORMANCE_FILE.vectors) {
+    const name = `Vector ${vector.id}: ${vector.notation}`
+
+    // Known conformance gaps — mark as todo with explanation
+    if (KNOWN_CONFORMANCE_GAPS[vector.id] !== undefined) {
+      test.todo(`${name} — CONFORMANCE GAP: ${KNOWN_CONFORMANCE_GAPS[vector.id]}`)
+      continue
+    }
+
+    // Error vectors — assert roll() throws
+    if ('expectedError' in vector && vector.expectedError) {
+      test(name, () => {
+        expect(() => roll(vector.notation)).toThrow()
+      })
+      continue
+    }
+
+    // Indeterminate vectors — skip with explanation
+    if (
+      !('expectedPool' in vector) ||
+      vector.expectedPool === null ||
+      vector.expectedTotal === null
+    ) {
+      test.skip(`${name} (indeterminate — expectedPool/expectedTotal is null; see spec note)`, () => {
+        // No assertion possible without a deterministic expected value
+      })
+      continue
+    }
+
+    // Custom faces dice (non-numeric pool values like strings) — skip
+    // Vector 31: d{fire,ice,lightning} — expectedPool contains strings
+    if (
+      Array.isArray(vector.expectedPool) &&
+      vector.expectedPool.some((v: unknown) => typeof v !== 'number')
+    ) {
+      test.skip(`${name} (custom string faces — createQueueRandom only handles numeric faces)`, () => {
+        // Non-numeric custom face values cannot be deterministically seeded
+      })
+      continue
+    }
+
+    // Draw die — skip: Fisher-Yates shuffle in drawWithoutReplacement cannot be seeded
+    // via createQueueRandom's simple (v-1)/sides mapping
+    if (/^\d*DD\d+$/i.test(vector.notation)) {
+      test.skip(`${name} (draw die — Fisher-Yates shuffle incompatible with createQueueRandom)`, () => {
+        // drawWithoutReplacement uses Fisher-Yates which consumes rng() differently
+      })
+      continue
+    }
+
+    test(name, () => {
+      const notation = vector.notation
+      const expectedPool = vector.expectedPool as number[]
+      const expectedTotal = vector.expectedTotal!
+
+      // Determine die sides and build the queue
+      const { sides, queueRolls } = ((): { sides: number; queueRolls: number[] } => {
+        if (/^(\d+)?dF\.2$/i.test(notation)) {
+          // dF.2 — extended Fudge die, faces [-2,-1,0,1,2]
+          return {
+            sides: FATE_2_FACES.length,
+            queueRolls: (vector.seedRolls as number[]).map(v =>
+              faceValueToQueueIndex(v, FATE_2_FACES)
+            )
+          }
+        }
+        if (/^(\d+)?dF(\.1)?$/i.test(notation)) {
+          // dF — Fate Core die, faces [-1,0,1]
+          return {
+            sides: FATE_FACES.length,
+            queueRolls: (vector.seedRolls as number[]).map(v =>
+              faceValueToQueueIndex(v, FATE_FACES)
+            )
+          }
+        }
+        if (/^(\d+)?z(\d+)/i.test(notation)) {
+          // zN — zero-bias die, faces [0..N-1]
+          const match = /^(?:\d+)?z(\d+)/i.exec(notation)
+          const n = parseInt(match![1]!, 10)
+          const zbFaces = Array.from({ length: n }, (_: unknown, i: number) => i)
+          return {
+            sides: zbFaces.length,
+            queueRolls: (vector.seedRolls as number[]).map(v => faceValueToQueueIndex(v, zbFaces))
+          }
+        }
+        if (/^d%$/i.test(notation)) {
+          // d% — percentile die, 1d100
+          return { sides: 100, queueRolls: vector.seedRolls as number[] }
+        }
+        if (/^(\d+)?g(\d+)/i.test(notation)) {
+          // gN — geometric die: rolls standard NdS until non-max, uses sides from notation
+          const match = /^(?:\d+)?g(\d+)/i.exec(notation)
+          if (!match) throw new Error(`Cannot extract sides from geometric notation: ${notation}`)
+          return { sides: parseInt(match[1]!, 10), queueRolls: vector.seedRolls as number[] }
+        }
+        // Standard NdS — extract sides from notation (handles modifiers after dN)
+        const match = /^(?:\d+)?[dD](\d+)/i.exec(notation)
+        if (!match) throw new Error(`Cannot extract sides from notation: ${notation}`)
+        return { sides: parseInt(match[1]!, 10), queueRolls: vector.seedRolls as number[] }
+      })()
+
+      const rerollRolls = 'rerollRolls' in vector ? (vector.rerollRolls as number[]) : undefined
+      const explodeRolls = 'explodeRolls' in vector ? (vector.explodeRolls as number[]) : undefined
+      const compoundRolls =
+        'compoundRolls' in vector ? (vector.compoundRolls as number[]) : undefined
+      const penetrateRolls =
+        'penetrateRolls' in vector ? (vector.penetrateRolls as number[]) : undefined
+      const sequenceRolls =
+        'sequenceRolls' in vector ? (vector.sequenceRolls as number[]) : undefined
+
+      const queueRandom = createQueueRandom({
+        sides,
+        rolls: queueRolls,
+        ...(rerollRolls !== undefined ? { rerollRolls } : {}),
+        ...(explodeRolls !== undefined ? { explodeRolls } : {}),
+        ...(compoundRolls !== undefined ? { compoundRolls } : {}),
+        ...(penetrateRolls !== undefined ? { penetrateRolls } : {}),
+        ...(sequenceRolls !== undefined ? { sequenceRolls } : {})
+      })
+
+      const result = roll(notation, { randomFn: queueRandom })
+      const record = result.rolls[0]!
+
+      expect(record.rolls).toEqual(expectedPool)
+      expect(result.total).toBe(expectedTotal)
+    })
+  }
+})

--- a/packages/roller/__tests__/support/createQueueRandom.test.ts
+++ b/packages/roller/__tests__/support/createQueueRandom.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import { roll } from '../../src/roll'
+import { createQueueRandom } from '../../test-utils/src/queueRandom'
+
+describe('createQueueRandom', () => {
+  describe('basic mapping', () => {
+    test('maps die value v to (v - 1) / sides', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [3] })
+      expect(rng()).toBe((3 - 1) / 6)
+    })
+
+    test('maps minimum die value 1 to 0', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [1] })
+      expect(rng()).toBe(0)
+    })
+
+    test('maps maximum die value to (sides - 1) / sides', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [6] })
+      expect(rng()).toBe((6 - 1) / 6)
+    })
+
+    test('drains queue in order', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [1, 3, 6] })
+      expect(rng()).toBe(0)
+      expect(rng()).toBe((3 - 1) / 6)
+      expect(rng()).toBe((6 - 1) / 6)
+    })
+
+    test('works with d20', () => {
+      const rng = createQueueRandom({ sides: 20, rolls: [15] })
+      expect(rng()).toBe((15 - 1) / 20)
+    })
+  })
+
+  describe('modifier roll arrays', () => {
+    test('concatenates rolls and rerollRolls in order', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [2], rerollRolls: [5] })
+      expect(rng()).toBe((2 - 1) / 6)
+      expect(rng()).toBe((5 - 1) / 6)
+    })
+
+    test('concatenates in priority order: rolls, reroll, explode, compound, penetrate, sequence', () => {
+      const rng = createQueueRandom({
+        sides: 6,
+        rolls: [1],
+        rerollRolls: [2],
+        explodeRolls: [3],
+        compoundRolls: [4],
+        penetrateRolls: [5],
+        sequenceRolls: [6]
+      })
+      expect(rng()).toBe((1 - 1) / 6)
+      expect(rng()).toBe((2 - 1) / 6)
+      expect(rng()).toBe((3 - 1) / 6)
+      expect(rng()).toBe((4 - 1) / 6)
+      expect(rng()).toBe((5 - 1) / 6)
+      expect(rng()).toBe((6 - 1) / 6)
+    })
+
+    test('omitted arrays are skipped', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [2], explodeRolls: [4] })
+      expect(rng()).toBe((2 - 1) / 6)
+      expect(rng()).toBe((4 - 1) / 6)
+    })
+  })
+
+  describe('queue exhaustion', () => {
+    test('throws when queue is exhausted', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [3] })
+      rng() // consume the only value
+      expect(() => rng()).toThrow()
+    })
+
+    test('throws with helpful message when queue is exhausted', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [3] })
+      rng()
+      expect(() => rng()).toThrow('exhausted')
+    })
+  })
+
+  describe('integration with roll()', () => {
+    test('produces expected die value when used as randomFn in roll()', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [4] })
+      const result = roll({ sides: 6, quantity: 1 }, { randomFn: rng })
+      expect(result.rolls[0]!.rolls).toEqual([4])
+    })
+
+    test('produces expected values for multi-die roll', () => {
+      const rng = createQueueRandom({ sides: 6, rolls: [2, 5, 3] })
+      const result = roll({ sides: 6, quantity: 3 }, { randomFn: rng })
+      expect(result.rolls[0]!.rolls).toEqual([2, 5, 3])
+    })
+  })
+})

--- a/packages/roller/src/modifiers/cap.ts
+++ b/packages/roller/src/modifiers/cap.ts
@@ -4,7 +4,6 @@ import {
   formatComparisonNotation,
   parseComparisonNotation
 } from '../notation/comparison'
-import { validateComparisonOptions } from '../lib/comparison'
 import { defineNotationSchema } from '../notation/schema'
 import type { NotationSchema } from '../notation/schema'
 import type { NotationDoc } from '../docs/modifierDocs'
@@ -138,7 +137,8 @@ export const capModifier: ModifierDefinition<ComparisonOptions> = {
     return { rolls: newRolls }
   },
 
-  validate: options => {
-    validateComparisonOptions('cap', options)
+  validate: _options => {
+    // Cap uses clamping semantics (floor/ceiling), not filter semantics.
+    // Any combination of lessThan/greaterThan is valid — no impossible range exists.
   }
 }

--- a/packages/roller/test-utils/src/index.ts
+++ b/packages/roller/test-utils/src/index.ts
@@ -1,4 +1,6 @@
 export { createSeededRandom } from './seededRandom'
+export { createQueueRandom } from './queueRandom'
+export type { QueueRandomOptions } from './queueRandom'
 export type { RandomFn } from '../../src'
 export { expectRollInRange, expectAllRollsInRange } from './assertions'
 export {

--- a/packages/roller/test-utils/src/queueRandom.ts
+++ b/packages/roller/test-utils/src/queueRandom.ts
@@ -1,0 +1,55 @@
+import type { RandomFn } from '../../src/lib/random'
+
+export interface QueueRandomOptions {
+  readonly sides: number
+  readonly rolls: readonly number[]
+  readonly rerollRolls?: readonly number[]
+  readonly explodeRolls?: readonly number[]
+  readonly compoundRolls?: readonly number[]
+  readonly penetrateRolls?: readonly number[]
+  readonly sequenceRolls?: readonly number[]
+}
+
+/**
+ * Creates a deterministic random function from pre-determined die values.
+ *
+ * Accepts literal die values (e.g., [3, 5, 2]) and returns a `RandomFn`
+ * that maps each value to the correct [0,1) range for use with roll().
+ *
+ * The roller converts randomFn() to a die value via:
+ *   Math.floor(rng() * sides) + 1
+ *
+ * So to produce die value `v` on a die with `sides` sides:
+ *   rng() must return (v - 1) / sides
+ *
+ * Roll arrays are consumed in modifier priority order:
+ *   rolls → rerollRolls → explodeRolls → compoundRolls → penetrateRolls → sequenceRolls
+ *
+ * @throws Error if the queue is exhausted before all calls are satisfied
+ */
+export function createQueueRandom(options: QueueRandomOptions): RandomFn {
+  const { sides, rolls, rerollRolls, explodeRolls, compoundRolls, penetrateRolls, sequenceRolls } =
+    options
+
+  const queue = [
+    ...rolls,
+    ...(rerollRolls ?? []),
+    ...(explodeRolls ?? []),
+    ...(compoundRolls ?? []),
+    ...(penetrateRolls ?? []),
+    ...(sequenceRolls ?? [])
+  ]
+
+  const state = { index: 0 }
+
+  return (): number => {
+    if (state.index >= queue.length) {
+      throw new Error(
+        `createQueueRandom: queue exhausted after ${queue.length} call(s). Provide more rolls.`
+      )
+    }
+    const value = queue[state.index]!
+    state.index += 1
+    return (value - 1) / sides
+  }
+}


### PR DESCRIPTION
## Summary

Addresses 6 findings from the unify-notation-docs brainstorm, hardening the conformance and documentation test infrastructure.

### Changes

- **S1: `createQueueRandom` test utility** — maps literal die values to `[0,1)` randomFn for deterministic conformance testing. Supports all modifier roll arrays (reroll, explode, compound, penetrate, sequence).

- **S2: Conformance vector test suite** — runs 48 spec vectors against `roll()` with deterministic seeding. **42 pass, 3 skip** (string faces, draw die, indeterminate), **3 conformance gaps found**:
  - Vector 2: bare `dN` notation rejected (spec requires it valid)
  - Vector 39: `!s{values}` semantic mismatch with spec
  - Vector 47: multiple Count modifiers silently accepted (spec requires rejection)

- **S3: Cap validation bug fix** — removed incorrect filter-semantics validation from cap modifier. Floor/ceiling clamp ranges like `{ lessThan: 3, greaterThan: 18 }` are now accepted. `KNOWN_OPTIONS_FAILURES` removed from rosettaStone.

- **S4: rosettaStone structural assertions** — doc examples now verify dice count matches parsed quantity and notation/options produce structurally equivalent results.

- **S5: Forms notation validation** — all 45 `NotationDoc.forms[].notation` templates validated against the live parser via substitution + `isDiceNotation()`.

- **S6: Conformance JSON `$id`** — added `https://notation.randsum.dev/conformance/v0.9.0.json` as the canonical schema identifier.

## Test plan
- [x] `bun run test` — 2689 roller tests pass (up from 2391)
- [x] `bun run typecheck` — 0 errors
- [x] `bun run --filter @randsum/rdn conformance:check` — exits 0
- [x] `bun run knip` — clean

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)