### PR TITLE
feat(discord-bot): add the Components V2 seam alongside the embed path

### DIFF
--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -8,8 +8,9 @@
  */
 import { describe, expect, test } from 'bun:test'
 import { commands as commandList } from '../../src/commands/index.js'
+import { ContainerBuilder, TextDisplayBuilder } from '../../src/utils/builders.js'
 import { dispatchInteraction, InteractionResponseType } from '../../src/worker/dispatch.js'
-import type { Command } from '../../src/types.js'
+import type { Command, RollView } from '../../src/types.js'
 
 const commands: ReadonlyMap<string, Command> = new Map(
   commandList.map(command => [command.data.name, command])
@@ -168,5 +169,63 @@ describe('dispatchInteraction', () => {
       commands
     ) as Rendered
     expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+  })
+
+  describe('the Components V2 seam', () => {
+    const buildView = (): RollView => [
+      new ContainerBuilder()
+        .setAccentColor(0x4fb3a5)
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent('## rendered by buildView'))
+    ]
+
+    const viewCommand: Command = { data: commandList[0]!.data, buildView }
+
+    function invokeView(options: { name: string; value: unknown }[] = []): Rendered {
+      return dispatchInteraction(
+        { type: 2, data: { name: 'probe', options } },
+        new Map([['probe', viewCommand]])
+      ) as Rendered
+    }
+
+    test('a command defining buildView is rendered as components, not embeds', () => {
+      const response = invokeView()
+      expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+      expect(response.data?.embeds).toBeUndefined()
+      // Container is component type 17.
+      expect(response.data?.components?.[0]).toMatchObject({ type: 17 })
+    })
+
+    test('the IsComponentsV2 flag is always set on a view response', () => {
+      // Without it Discord reads `components` as legacy action rows and rejects
+      // the container outright, so this flag is load-bearing, not cosmetic.
+      expect(invokeView().data?.flags).toBe(32768)
+    })
+
+    test('hidden composes with the V2 flag rather than replacing it', () => {
+      expect(invokeView([{ name: 'hidden', value: true }]).data?.flags).toBe(32768 | 64)
+    })
+
+    test('buildView wins when a command defines both renderers', () => {
+      const both: Command = {
+        data: commandList[0]!.data,
+        buildView,
+        buildEmbed: () => {
+          throw new Error('the embed path must not run when buildView exists')
+        }
+      }
+      const response = dispatchInteraction(
+        { type: 2, data: { name: 'probe' } },
+        new Map([['probe', both]])
+      ) as Rendered
+      expect(response.data?.components?.[0]).toMatchObject({ type: 17 })
+    })
+
+    test('a command with neither renderer still reports itself unavailable', () => {
+      const response = dispatchInteraction(
+        { type: 2, data: { name: 'probe' } },
+        new Map([['probe', { data: commandList[0]!.data }]])
+      ) as Rendered
+      expect(response.data?.embeds?.[0]?.title).toBe('Error')
+    })
   })
 })

--- a/apps/discord-bot/src/types.ts
+++ b/apps/discord-bot/src/types.ts
@@ -4,8 +4,22 @@ import type { SlashCommandBuilder, SlashCommandOptionsOnlyBuilder } from 'discor
 // `.length` and accepting hex-string colours. The two are therefore distinct
 // types, and a command that returns one cannot satisfy a signature demanding
 // the other. Since command renderers must run on workerd, the portable one wins.
-import type { EmbedBuilder } from './utils/builders.js'
+import type { ContainerBuilder, EmbedBuilder } from './utils/builders.js'
 import type { CommandContext } from './commands/lib/context.js'
+
+/**
+ * A rendered command response: one Components V2 container per dice pool.
+ *
+ * An array rather than a single container because a multi-pool roll
+ * (`2d6 1d8`) and a repeat (`4d6Lx6`) genuinely produce several results, and
+ * the embed renderer's habit of showing only `rolls[0]` while reporting the
+ * combined total was a bug, not a simplification.
+ *
+ * Narrowed to `ContainerBuilder` rather than the wider top-level component
+ * union because every command wants an accent bar, and a select menu can nest
+ * inside a container — so the dispatcher never has to branch on component kind.
+ */
+export type RollView = readonly ContainerBuilder[]
 
 export interface Command {
   data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder
@@ -22,6 +36,17 @@ export interface Command {
    * guess. Every command in the barrel currently has one, and
    * `__tests__/worker/dispatch.test.ts` holds that line.
    */
+  /**
+   * The Components V2 renderer — where every command is heading.
+   *
+   * Present alongside `buildEmbed` on purpose: the dispatcher prefers this
+   * when a command defines it and falls back to the embed path otherwise, so
+   * commands migrate one file at a time with the bot shippable at every
+   * commit. Once every command defines `buildView`, `buildEmbed` and the
+   * fallback branch both go.
+   */
+  buildView?: (context: CommandContext) => RollView
+  /** @deprecated Superseded by `buildView`; removed once every command migrates. */
   buildEmbed?: (context: CommandContext) => EmbedBuilder
   /**
    * Interactive components to attach alongside the embed, as raw API JSON.

--- a/apps/discord-bot/src/utils/builders.ts
+++ b/apps/discord-bot/src/utils/builders.ts
@@ -21,13 +21,30 @@
  * The rule this encodes: **command files import from here, never from
  * `discord.ts`.** Anything that needs the gateway barrel is transport, and
  * belongs in the gateway entry point.
+ *
+ * The Components V2 builders (`ContainerBuilder`, `SectionBuilder`,
+ * `TextDisplayBuilder`, `SeparatorBuilder`, `ThumbnailBuilder`) are here for
+ * the same reason as the rest: they are pure data construction, and they ship
+ * in the version already pinned — Components V2 needed no dependency bump.
  */
 export {
   ActionRowBuilder,
   ButtonBuilder,
+  ContainerBuilder,
   EmbedBuilder,
+  SectionBuilder,
+  SeparatorBuilder,
   SlashCommandBuilder,
-  StringSelectMenuBuilder
+  StringSelectMenuBuilder,
+  TextDisplayBuilder,
+  ThumbnailBuilder
 } from '@discordjs/builders'
 
-export { ComponentType, MessageFlags } from 'discord-api-types/v10'
+export {
+  ButtonStyle,
+  ComponentType,
+  MessageFlags,
+  SeparatorSpacingSize
+} from 'discord-api-types/v10'
+
+export type { APIContainerComponent } from 'discord-api-types/v10'

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -16,7 +16,7 @@ import { MessageFlags } from '../utils/builders.js'
 import { optionsFromPayload } from '../commands/lib/context.js'
 import { defaultErrorMessage } from '../commands/lib/index.js'
 import { buildNotationView, NOTATION_SELECT_ID } from '../commands/lib/notationView.js'
-import type { Command } from '../types.js'
+import type { Command, RollView } from '../types.js'
 
 /** Discord's interaction type numbers. */
 export const InteractionType = {
@@ -31,9 +31,13 @@ export const InteractionType = {
 export const InteractionResponseType = {
   Pong: 1,
   ChannelMessageWithSource: 4,
+  DeferredChannelMessageWithSource: 5,
+  /** Acknowledges a component without showing a loading state. */
+  DeferredMessageUpdate: 6,
   /** Replaces the message the component is attached to, in place. */
   UpdateMessage: 7,
-  AutocompleteResult: 8
+  AutocompleteResult: 8,
+  Modal: 9
 } as const
 
 /** The subset of an interaction payload this dispatcher reads. */
@@ -64,6 +68,24 @@ export interface InteractionPayload {
 function resolveDisplayName(payload: InteractionPayload): string {
   const user = payload.member?.user ?? payload.user
   return user?.global_name ?? user?.username ?? 'Adventurer'
+}
+
+/**
+ * Wrap a rendered view in a Components V2 interaction response.
+ *
+ * `IsComponentsV2` is what switches Discord from the embed layout to the
+ * component tree; without it the `components` array is read as legacy action
+ * rows and a container is rejected. It composes with `Ephemeral` as a normal
+ * bit flag — 32768 | 64 — so the `hidden` option keeps working unchanged.
+ */
+export function viewResponse(view: RollView, hidden: boolean): unknown {
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      flags: MessageFlags.IsComponentsV2 | (hidden ? MessageFlags.Ephemeral : 0),
+      components: view.map(container => container.toJSON())
+    }
+  }
 }
 
 function errorResponse(message: string): unknown {
@@ -132,23 +154,30 @@ export function dispatchInteraction(
     return errorResponse(`Unknown command: \`/${name}\`. It may have been removed.`)
   }
 
-  if (command.buildEmbed === undefined) {
+  if (command.buildView === undefined && command.buildEmbed === undefined) {
     return errorResponse(`\`/${name}\` is not available on this deployment yet.`)
   }
 
   const options = optionsFromPayload(payload.data?.options)
 
   try {
-    const embed = command.buildEmbed({
-      options,
-      userDisplayName: resolveDisplayName(payload)
-    })
+    const context = { options, userDisplayName: resolveDisplayName(payload) }
     const hidden = options.getBoolean('hidden') ?? false
 
-    const components = command.buildComponents?.({
-      options,
-      userDisplayName: resolveDisplayName(payload)
-    })
+    // Components V2 first. A command that defines `buildView` never touches the
+    // embed path, and the two are mutually exclusive per message — the V2 flag
+    // forbids `embeds` outright, so there is no blending them.
+    if (command.buildView !== undefined) {
+      return viewResponse(command.buildView(context), hidden)
+    }
+
+    // Legacy embed path. Deleted once every command defines `buildView`.
+    if (command.buildEmbed === undefined) {
+      return errorResponse(`\`/${name}\` is not available on this deployment yet.`)
+    }
+
+    const embed = command.buildEmbed(context)
+    const components = command.buildComponents?.(context)
 
     return {
       type: InteractionResponseType.ChannelMessageWithSource,


### PR DESCRIPTION
## Summary

Groundwork for migrating every command to Discord's Components V2. **Nothing user-visible changes** — no command defines the new renderer yet. This is the load-bearing PR of the stack: after it, each command migrates in its own PR and `main` stays shippable at every commit.

**Stacked on #1239** — review that first; this PR's diff is against it, not `main`.

## What's here

**The barrel widens.** `utils/builders.ts` re-exported 5 of the ~28 classes `@discordjs/builders` ships. It now also carries `ContainerBuilder`, `SectionBuilder`, `TextDisplayBuilder`, `SeparatorBuilder`, `ThumbnailBuilder`, plus `ButtonStyle` and `SeparatorSpacingSize`.

**No dependency bump is needed.** The pinned `@discordjs/builders` 1.14.1 is the current latest release and already contains the entire V2 builder set; `discord-api-types` 0.38.49 already defines `MessageFlags.IsComponentsV2 = 32768` and every V2 `ComponentType`. I verified this by extracting the actual pinned tarballs rather than trusting the docs.

**`Command` gains `buildView`,** returning `RollView = readonly ContainerBuilder[]` — one container per dice pool. The array shape exists because a multi-pool roll genuinely produces several results; rendering only `rolls[0]` was the bug fixed in #1239. It's narrowed to containers rather than the wider top-level union so the dispatcher never branches on component kind — a select menu can nest *inside* a container, so `/notation` loses nothing by this narrowing.

**The dispatcher speaks both dialects.** `buildView` wins when defined; otherwise the embed path runs unchanged. `buildEmbed` is marked `@deprecated` and both it and the fallback branch get deleted at the end of the stack.

## Why a seam rather than a cutover

`Command.buildEmbed` is load-bearing across 10 command files, the dispatcher, and 13 test files. A single cutover would be one unreviewable diff that either lands entirely or not at all. With the seam, each command migration is independently reviewable and independently revertable.

The one thing this trades away: two renderer paths coexist for the length of the stack. That's why deleting the embed path is its own scheduled PR rather than left to drift — a permanent fork would mean two renderers, two test styles, and a "which does this command use?" question forever.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

- `viewResponse` sets `IsComponentsV2`, which is what switches Discord from the embed layout to the component tree — without it a container is rejected as a malformed action row. It composes with `Ephemeral` as an ordinary bit flag; a test pins `32768 | 64` so a future refactor can't silently drop ephemeral behaviour.
- There's a second `command.buildEmbed === undefined` check inside the `try` that looks redundant against the outer guard. It is required: TypeScript can't narrow `buildEmbed` across the early return for `buildView`. Flagging so it doesn't read as an oversight.
- Also fills in the `InteractionResponseType` members the local enum was missing (`DeferredChannelMessageWithSource`, `DeferredMessageUpdate`, `Modal`). Unused today; `Modal` is wanted later in the stack.
- `bun test` does not typecheck, so the seam tests initially passed while violating `exactOptionalPropertyTypes`. Caught by the `check` chain — worth remembering for the command-migration PRs to come.

## Checklist

- [x] `bun run check:all` passes for the touched package (typecheck + format + lint + test)
- [x] Tests cover the change — 110 pass, up from 105; new coverage for V2-vs-embed precedence, the flag value, ephemeral composition, and the unavailable-command path
- [x] Bundle size limits respected (no new dependencies)
- [x] No public API change outside the private bot
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_