### PR TITLE
feat(discord-bot): add the shared Components V2 renderer

### DIFF
--- a/apps/discord-bot/__tests__/commands/lib/view.test.ts
+++ b/apps/discord-bot/__tests__/commands/lib/view.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Covers the shared Components V2 renderer against the REAL trace engine.
+ *
+ * `renderTrace` is a thin mapping over `@randsum/roller/trace`, so the trace
+ * itself is deliberately NOT mocked — mocking it would test the mapping against
+ * a fiction.
+ *
+ * The records below are literal fixtures copied from real `roll()` output
+ * rather than produced by calling `roll()` here. Two reasons: a live roll is
+ * random, so an assertion about which die was struck through would be flaky;
+ * and sibling test files call `mock.module('@randsum/roller', ...)`, which
+ * leaks across files and made `roll()` return `undefined` in this one.
+ */
+import { describe, expect, test } from 'bun:test'
+import type { TraceableRollRecord } from '@randsum/roller/trace'
+import {
+  CUSTOM_ID_LIMIT,
+  renderFacts,
+  renderTrace,
+  rollContainer
+} from '../../../src/commands/lib/view.js'
+import { accentsOf, buttonIdsOf, linesOf, textOf } from '../../lib/view.js'
+
+/** Real `roll('4d6L')` output — one die dropped. */
+const DROP_RECORD: TraceableRollRecord = {
+  initialRolls: [1, 4, 2, 6],
+  rolls: [2, 4, 6],
+  modifierLogs: [{ modifier: 'drop', options: { lowest: 1 }, added: [], removed: [1] }],
+  appliedTotal: 12,
+  total: 12
+}
+
+/** Real `roll('2d6+3')` output — dice untouched, arithmetic applied. */
+const ARITHMETIC_RECORD: TraceableRollRecord = {
+  initialRolls: [3, 5],
+  rolls: [3, 5],
+  modifierLogs: [{ modifier: 'plus', options: 3, added: [], removed: [] }],
+  appliedTotal: 11,
+  total: 11
+}
+
+/** Real `roll('4d6R{<6}')` output — two dice rerolled into sixes. */
+const REROLL_RECORD: TraceableRollRecord = {
+  initialRolls: [2, 6, 2, 6],
+  rolls: [6, 6, 6, 6],
+  modifierLogs: [
+    {
+      modifier: 'reroll',
+      options: { lessThan: 6 },
+      added: [6, 6],
+      removed: [2, 2],
+      replacements: [
+        { from: 2, to: 6 },
+        { from: 2, to: 6 }
+      ]
+    }
+  ],
+  appliedTotal: 24,
+  total: 24
+}
+
+/** Real `roll('2d6')` output — nothing modified it. */
+const PLAIN_RECORD: TraceableRollRecord = {
+  initialRolls: [4, 5],
+  rolls: [4, 5],
+  modifierLogs: [],
+  appliedTotal: 9,
+  total: 9
+}
+
+describe('renderTrace', () => {
+  test('an unmodified pool renders exactly one line, with no total', () => {
+    // The engine emits no `finalRolls` step when nothing modified the pool —
+    // there is no arithmetic to summarise. So a plain 2d6 gets one line, and
+    // the total reaches the reader through the headline instead. Pinned here
+    // because a renderer that assumed a trailing total would silently print
+    // nothing for the bot's single most common roll.
+    const lines = renderTrace(PLAIN_RECORD)
+    expect(lines).toEqual(['**Rolled**  4 5'])
+  })
+
+  test('a dropped die is struck through and the kept dice are not', () => {
+    expect(renderTrace(DROP_RECORD)).toEqual([
+      '**Rolled**  1 4 2 6',
+      '**Drop Lowest 1**  ~~1~~ 4 2 6',
+      '**Total**  2 + 4 + 6'
+    ])
+  })
+
+  test('a reroll marks the replaced dice struck and the new dice bold', () => {
+    // The information the old renderer lost entirely: two parallel plain lists
+    // showed [2,6,2,6] and [6,6,6,6] with nothing saying which changed.
+    expect(renderTrace(REROLL_RECORD)).toEqual([
+      '**Rolled**  2 6 2 6',
+      '**Reroll Less than 6**  ~~2~~ ~~2~~ **6** **6** 6 6',
+      '**Total**  6 + 6 + 6 + 6'
+    ])
+  })
+
+  test('arithmetic appears as its own step, not folded into the dice', () => {
+    expect(renderTrace(ARITHMETIC_RECORD)).toEqual([
+      '**Rolled**  3 5',
+      '**Add**  +3',
+      '**Total**  3 + 5 + 3'
+    ])
+  })
+})
+
+describe('renderFacts', () => {
+  test('joins label/value pairs into the line that replaces the field grid', () => {
+    expect(
+      renderFacts([
+        { label: 'Stat', value: '+2' },
+        { label: 'Forward', value: '+1' }
+      ])
+    ).toBe('**Stat** +2  ·  **Forward** +1')
+  })
+})
+
+describe('rollContainer', () => {
+  const base = { accent: 0x4fb3a5, headline: '◆ Strong Hit' }
+
+  test('the headline is an h2, which only Components V2 can render', () => {
+    expect(linesOf([rollContainer(base)])[0]).toBe('## ◆ Strong Hit')
+  })
+
+  test('the accent is whatever the caller passed, not a constant', () => {
+    expect(accentsOf([rollContainer({ ...base, accent: 0xb01b2e })])[0]).toBe(0xb01b2e)
+  })
+
+  test('attribution is always present, even with no derivation', () => {
+    expect(textOf([rollContainer(base)])).toContain('rolled with 👹 by randsum.dev')
+  })
+
+  test('a derivation is prefixed to the attribution as subtext', () => {
+    const text = textOf([rollContainer({ ...base, derivation: '2d6(4,5) +2 = 11' })])
+    expect(text).toContain('-# 2d6(4,5) +2 = 11 · rolled with 👹 by randsum.dev')
+  })
+
+  test('a reroll button is attached beside the body when an id is given', () => {
+    const view = [rollContainer({ ...base, body: ['dice'], rerollId: 'reroll:roll:2d6' })]
+    expect(buttonIdsOf(view)).toEqual(['reroll:roll:2d6'])
+  })
+
+  test('an over-long custom_id drops the button rather than sending an invalid one', () => {
+    // Discord rejects the whole message when a component exceeds the limit, so
+    // silently losing the button is the only safe failure.
+    const view = [
+      rollContainer({ ...base, body: ['dice'], rerollId: 'r'.repeat(CUSTOM_ID_LIMIT + 1) })
+    ]
+    expect(buttonIdsOf(view)).toEqual([])
+    expect(textOf(view)).toContain('dice')
+  })
+
+  test('a body-less container attaches no button and still renders', () => {
+    const view = [rollContainer({ ...base, rerollId: 'reroll:x' })]
+    expect(buttonIdsOf(view)).toEqual([])
+    expect(linesOf(view).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/discord-bot/__tests__/lib/view.ts
+++ b/apps/discord-bot/__tests__/lib/view.ts
@@ -1,0 +1,54 @@
+/**
+ * Test helpers for reading a Components V2 view.
+ *
+ * Under embeds a test could say `expect(embed.data.title).toBe('Miss')`. A
+ * container has no title — it has a tree of text components — so the literal
+ * translation of that assertion is
+ *
+ *   expect(view[0]!.toJSON().components[0]!.content).toBe('## Miss')
+ *
+ * which is unreadable, and brittle for the wrong reason: it breaks when a
+ * separator moves, not when the text changes. These helpers flatten the tree so
+ * assertions stay about content.
+ */
+import { ComponentType } from '../../src/utils/builders.js'
+import type { APIContainerComponent } from '../../src/utils/builders.js'
+import type { RollView } from '../../src/types.js'
+
+type ContainerChild = APIContainerComponent['components'][number]
+
+function collectText(components: readonly ContainerChild[]): string[] {
+  return components.flatMap(component => {
+    if (component.type === ComponentType.TextDisplay) return [component.content]
+    if (component.type === ComponentType.Section) return collectText(component.components)
+    return []
+  })
+}
+
+/** Every text line in the view, in render order. */
+export function linesOf(view: RollView): string[] {
+  return view.flatMap(container => collectText(container.toJSON().components))
+}
+
+/** The whole view as one string — what most assertions want. */
+export function textOf(view: RollView): string {
+  return linesOf(view).join('\n')
+}
+
+/** Each container's accent colour, in order. */
+export function accentsOf(view: RollView): (number | null | undefined)[] {
+  return view.map(container => container.toJSON().accent_color)
+}
+
+/** Every button `custom_id` in the view — empty when no button was attached. */
+export function buttonIdsOf(view: RollView): string[] {
+  return view.flatMap(container =>
+    container.toJSON().components.flatMap(component => {
+      if (component.type !== ComponentType.Section) return []
+      const accessory = component.accessory
+      return accessory.type === ComponentType.Button && 'custom_id' in accessory
+        ? [accessory.custom_id ?? '']
+        : []
+    })
+  )
+}

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -4,6 +4,8 @@ import type { CommandContext } from './context.js'
 
 export type { CommandContext, CommandOptions } from './context.js'
 export { optionsFromPayload } from './context.js'
+export type { RollContainerOptions, ViewFact } from './view.js'
+export { CUSTOM_ID_LIMIT, renderFacts, renderTrace, rollContainer } from './view.js'
 
 interface CreateGameCommandOptions {
   readonly data: Command['data']

--- a/apps/discord-bot/src/commands/lib/view.ts
+++ b/apps/discord-bot/src/commands/lib/view.ts
@@ -1,0 +1,157 @@
+/**
+ * The shared Components V2 renderer — every command's output is built here.
+ *
+ * Under embeds each command assembled its own title, colour, fields and footer,
+ * which is how the bot ended up with fourteen colour literals across eight
+ * files, six mutually incompatible title shapes and seven different names for
+ * "the dice that were rolled". One renderer means those are decided once.
+ *
+ * The layout it produces, top to bottom:
+ *
+ *   ## ◆ Full Success — you do it.      <- headline: the outcome, in the game's words
+ *   Position: Risky · Effect: Standard  <- consequence: what it means mechanically
+ *   ────────────────────────────────    <- separator
+ *   Rolled  6 3 2 1                     <- the trace, one line per modifier step
+ *   Keep highest  ~~3~~ ~~2~~ ~~1~~ 6      (with an optional Reroll button beside it)
+ *   -# 4d6 keep highest → 6 · rolled …  <- derivation: the audit line
+ *
+ * Note what is absent: an embed field grid. Components V2 has no `inline`
+ * fields, so the three-across row is gone. Facts that used to be inline fields
+ * are joined into one ` · ` separated line by `renderFacts`, which reads better
+ * on a phone than three truncated columns did anyway.
+ */
+import { traceRoll, formatAsMath } from '@randsum/roller/trace'
+import type { TraceableRollRecord } from '@randsum/roller/trace'
+import {
+  ButtonBuilder,
+  ButtonStyle,
+  ContainerBuilder,
+  SectionBuilder,
+  SeparatorBuilder,
+  SeparatorSpacingSize,
+  TextDisplayBuilder
+} from '../../utils/builders.js'
+import { FOOTER_ATTRIBUTION } from '../../utils/constants.js'
+
+/**
+ * Discord caps a `custom_id` at 100 characters and rejects the whole message
+ * when a component exceeds it — so a reroll button carrying long notation has
+ * to be dropped rather than truncated.
+ */
+export const CUSTOM_ID_LIMIT = 100
+
+/** A label/value pair — the replacement for an inline embed field. */
+export interface ViewFact {
+  readonly label: string
+  readonly value: string
+}
+
+export interface RollContainerOptions {
+  /** Accent bar colour. Drives outcome tier, never a per-command constant. */
+  readonly accent: number
+  /** The outcome, in the game's own vocabulary. Rendered as an `##` header. */
+  readonly headline: string
+  /** What the outcome means mechanically. One or two sentences. */
+  readonly consequence?: string
+  /** Pre-rendered body lines — usually `renderTrace`, sometimes a plain list. */
+  readonly body?: readonly string[]
+  /** Label/value pairs shown as one ` · ` separated line above the body. */
+  readonly facts?: readonly ViewFact[]
+  /** The audit line: how the total was arrived at. Rendered as `-#` subtext. */
+  readonly derivation?: string
+  /** Encoded reroll state. Omitted — with the button — when over the id limit. */
+  readonly rerollId?: string
+}
+
+/** Joins label/value pairs into the single line that replaces the field grid. */
+export function renderFacts(facts: readonly ViewFact[]): string {
+  return facts.map(fact => `**${fact.label}** ${fact.value}`).join('  ·  ')
+}
+
+/**
+ * Renders one roll record as trace lines: what was rolled, what each modifier
+ * removed and added, and the final arithmetic.
+ *
+ * This is `@randsum/roller/trace` reaching Discord for the first time. The
+ * engine has always produced this step model — `packages/dice-ui` renders it on
+ * the website — while the bot hand-rolled `.join(', ')` and showed two parallel
+ * plain lists for the reader to diff by eye.
+ *
+ * Removed dice are struck through, added dice bold, unchanged dice plain, which
+ * is exactly the `DieBadge` variant scheme the web component uses.
+ */
+export function renderTrace(record: TraceableRollRecord): readonly string[] {
+  return traceRoll(record).flatMap(step => {
+    switch (step.kind) {
+      case 'rolls': {
+        const dice = [
+          ...step.removed.map(value => `~~${value}~~`),
+          ...step.added.map(value => `**${value}**`),
+          ...step.unchanged.map(value => String(value))
+        ]
+        return dice.length > 0 ? [`**${step.label}**  ${dice.join(' ')}`] : []
+      }
+      case 'arithmetic':
+        return [`**${step.label}**  ${step.display}`]
+      case 'finalRolls':
+        return [`**Total**  ${formatAsMath(step.rolls, step.arithmeticDelta)}`]
+      case 'divider':
+        return []
+    }
+  })
+}
+
+/**
+ * Builds one container. Commands describe *what* to say; this decides how.
+ *
+ * The reroll button is attached as a `Section` accessory rather than an action
+ * row, so it sits beside the dice instead of stranded beneath them — the one
+ * layout embeds cannot express at all.
+ */
+export function rollContainer(options: RollContainerOptions): ContainerBuilder {
+  const container = new ContainerBuilder().setAccentColor(options.accent)
+
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${options.headline}`))
+
+  if (options.consequence !== undefined && options.consequence.length > 0) {
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(options.consequence))
+  }
+
+  if (options.facts !== undefined && options.facts.length > 0) {
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(renderFacts(options.facts))
+    )
+  }
+
+  const body = options.body ?? []
+  if (body.length > 0) {
+    container.addSeparatorComponents(
+      new SeparatorBuilder().setDivider(true).setSpacing(SeparatorSpacingSize.Small)
+    )
+
+    const text = new TextDisplayBuilder().setContent(body.join('\n'))
+    const rerollable = options.rerollId !== undefined && options.rerollId.length <= CUSTOM_ID_LIMIT
+
+    if (rerollable) {
+      container.addSectionComponents(
+        new SectionBuilder().addTextDisplayComponents(text).setButtonAccessory(
+          new ButtonBuilder()
+            .setCustomId(options.rerollId ?? '')
+            .setLabel('Reroll')
+            .setStyle(ButtonStyle.Secondary)
+        )
+      )
+    } else {
+      container.addTextDisplayComponents(text)
+    }
+  }
+
+  const derivation =
+    options.derivation !== undefined && options.derivation.length > 0
+      ? `${options.derivation} · ${FOOTER_ATTRIBUTION}`
+      : FOOTER_ATTRIBUTION
+
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${derivation}`))
+
+  return container
+}

--- a/apps/discord-bot/src/utils/constants.ts
+++ b/apps/discord-bot/src/utils/constants.ts
@@ -1,3 +1,12 @@
 export const embedFooterDetails = {
   text: 'Rolled with 👹 by randsum.dev'
 }
+
+/**
+ * The attribution half of the footer line.
+ *
+ * Components V2 has no footer primitive — the line is composed by hand as `-#`
+ * subtext — and every roll now prefixes it with that roll's derivation, so the
+ * constant is the attribution alone rather than the whole string.
+ */
+export const FOOTER_ATTRIBUTION = 'rolled with 👹 by randsum.dev'


### PR DESCRIPTION
## Summary

The renderer every command will route through, plus the test helpers that make asserting against a component tree readable. **No command uses it yet** — migrations are the next PRs in the stack.

**Stacked on #1240** (which is stacked on #1239). Review those first; this diff is against #1240.

## `renderTrace` is the centrepiece

`@randsum/roller/trace` exports `traceRoll()`, which returns an ordered step model of a roll — what was rolled, what each modifier removed and added, what the arithmetic did. `packages/dice-ui` already renders it on the website. **No file in `apps/discord-bot` imported it**; every command hand-rolled `.join(', ')`.

Discord's markdown maps onto that model directly — struck for removed, bold for added, plain for unchanged, which is exactly the `DieBadge` variant scheme `RollSteps.tsx` uses:

```
**Rolled**               2 6 2 6
**Reroll Less than 6**   ~~2~~ ~~2~~ **6** **6** 6 6
**Total**                6 + 6 + 6 + 6
```

That replaces the `Initial Rolls` / `Modified Rolls` pair, which printed two plain lists and left the reader to diff ten numbers by eye.

## The rest

**`rollContainer()`** takes *what* to say — headline, consequence, facts, body, derivation — and decides *how*. One place now owns what used to be 14 colour literals across 8 files, 6 incompatible title shapes, and 7 names for "the dice that were rolled".

**`renderFacts()`** — Components V2 has no `inline` field grid, so label/value pairs join into one ` · ` separated line. Three truncated columns on a phone weren't serving anyone.

**The reroll button attaches as a `Section` accessory**, beside the dice rather than stranded in a row beneath — the one layout embeds cannot express at all. An over-long `custom_id` drops the button rather than emitting it: Discord rejects the *entire message* when a component exceeds 100 chars, so a missing button is the only safe failure.

**`__tests__/lib/view.ts`** flattens a container tree so assertions stay about content. Without it, the V2 equivalent of `expect(embed.data.title).toBe('Miss')` is `expect(view[0]!.toJSON().components[0]!.content).toBe('## Miss')` — which breaks when a separator moves rather than when the text changes. It ships *before* the first command migrates so no test gets written twice.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

Two things I'd want a second opinion on:

- **`traceRoll` emits no `finalRolls` step for an unmodified pool.** A plain `2d6` gets one line and no total, so the total has to reach the reader via the headline. That's pinned by a test with a comment, because a renderer assuming a trailing total would silently print nothing for the bot's most common roll. Worth confirming that's the engine's intended contract and not an oversight there.
- **The trace fixtures are literal records copied from real `roll()` output**, not live calls. A live roll is random, so asserting *which* die was struck through would be flaky — and separately, sibling test files call `mock.module('@randsum/roller', ...)`, which leaks across files **even under `--isolate`** and made `roll()` return `undefined` here. That leak is pre-existing and worth knowing about; it will bite the command-migration PRs too.

Also: `constants.ts` gains `FOOTER_ATTRIBUTION` alongside the existing `embedFooterDetails`. V2 has no footer primitive — the line is composed by hand as `-#` subtext — and each roll now prefixes its derivation, so the constant is the attribution alone. `embedFooterDetails` stays until the embed path is deleted.

## Checklist

- [x] `bun run check:all` passes for the touched package
- [x] Tests cover the change — 122 pass, up from 110; new coverage for each trace step kind, the fact line, the accent, the derivation footer, and both reroll-button paths
- [x] Bundle size limits respected (no new dependencies; `@randsum/roller/trace` is an existing workspace subpath)
- [x] No public API change outside the private bot
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_