### PR TITLE
feat(discord-bot): migrate the six game commands to Components V2

### DIFF
--- a/apps/discord-bot/__tests__/commands/blades.test.ts
+++ b/apps/discord-bot/__tests__/commands/blades.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
 import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { BLADES } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
 const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
   result: 'success',
@@ -12,44 +14,58 @@ void mock.module('@randsum/games/blades', () => ({ roll: mockRoll }))
 
 const { bladesCommand } = await import('../../src/commands/blades.js')
 
-function render(dice: number): APIEmbed {
-  return bladesCommand.buildEmbed!(makeContext([{ name: 'dice', value: dice }])).toJSON()
+function render(dice: number): RollView {
+  return bladesCommand.buildView!(makeContext([{ name: 'dice', value: dice }]))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(() => ({
+    result: 'success',
+    total: 5,
+    rolls: [{ initialRolls: [5, 3], rolls: [5], modifierLogs: [] }]
+  }))
 })
 
 describe('bladesCommand', () => {
-  test('success result', () => {
-    expect(render(3).title).toBe('Success!')
+  test("a full success leads with the book's own phrasing", () => {
+    const view = render(3)
+    expect(textOf(view)).toContain('## ◆ Full Success')
+    expect(textOf(view)).toContain('You do it.')
+    expect(accentsOf(view)[0]).toBe(BLADES.success)
   })
 
-  test('critical result', () => {
+  test('a critical is distinct from a plain success in both word and colour', () => {
     mockRoll.mockImplementationOnce(() => ({
       result: 'critical' as const,
       total: 6,
       rolls: [{ initialRolls: [6, 6], rolls: [6, 6], modifierLogs: [] }]
     }))
-    expect(render(2).title).toBe('Critical Success!')
+    const view = render(2)
+    expect(textOf(view)).toContain('## ✸ Critical')
+    expect(accentsOf(view)[0]).toBe(BLADES.critical)
   })
 
-  test('partial result', () => {
+  test('a partial says what it costs', () => {
     mockRoll.mockImplementationOnce(() => ({
       result: 'partial' as const,
       total: 4,
       rolls: [{ initialRolls: [4, 3], rolls: [4], modifierLogs: [] }]
     }))
-    expect(render(2).title).toBe('Partial Success')
+    const view = render(2)
+    expect(textOf(view)).toContain('## ◈ Partial Success')
+    expect(textOf(view)).toContain("there's a consequence")
+    expect(accentsOf(view)[0]).toBe(BLADES.partial)
   })
 
-  test('failure result', () => {
+  test('a bad outcome is not the same red as a validation error', () => {
     mockRoll.mockImplementationOnce(() => ({
       result: 'failure' as const,
       total: 2,
       rolls: [{ initialRolls: [2, 1], rolls: [2], modifierLogs: [] }]
     }))
-    expect(render(1).title).toBe('Failure')
+    const view = render(1)
+    expect(textOf(view)).toContain('## ✕ Bad Outcome')
+    expect(accentsOf(view)[0]).toBe(BLADES.failure)
   })
 
   test('reads the dice option Discord actually sends', () => {
@@ -60,15 +76,33 @@ describe('bladesCommand', () => {
   test('0 dice is a real value, not an absent one', () => {
     // Blades rolls 2 dice and takes the lowest at rating 0, so `?? default`
     // logic that treats 0 as missing would silently change the mechanic.
-    const embed = render(0)
-    const pool = (embed.fields ?? []).find(field => field.name === 'Dice Pool')
-    expect(pool?.value).toBe('0 dice (rolled 2, taking lowest)')
+    mockRoll.mockImplementationOnce(() => ({
+      result: 'failure' as const,
+      total: 2,
+      rolls: [{ initialRolls: [2, 5], rolls: [2], modifierLogs: [] }]
+    }))
+    expect(textOf(render(0))).toContain('0 dice — roll two, take the worst')
+  })
+
+  test('at 0 dice the KEPT die is bold, not the highest', () => {
+    // The regression this guards: the renderer used to bold `Math.max(...)`,
+    // so a (2, 5) desperate roll bolded the 5 and labelled it "Highest Roll"
+    // while the headline read Failure — from the 2 the engine actually kept.
+    mockRoll.mockImplementationOnce(() => ({
+      result: 'failure' as const,
+      total: 2,
+      rolls: [{ initialRolls: [2, 5], rolls: [2], modifierLogs: [] }]
+    }))
+    const text = textOf(render(0))
+    expect(text).toContain('**2**')
+    expect(text).toContain('~~5~~')
+    expect(text).toContain('**Deciding Die** 2')
   })
 
   test('error path: a failing roll propagates', () => {
     // The dispatcher owns error rendering now — it catches this and returns an
-    // "Error" embed (covered in __tests__/worker/dispatch.test.ts). What
-    // buildEmbed owes it is a throw, not a half-built embed.
+    // error response (covered in __tests__/worker/dispatch.test.ts). What the
+    // renderer owes it is a throw, not a half-built view.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })

--- a/apps/discord-bot/__tests__/commands/dh.test.ts
+++ b/apps/discord-bot/__tests__/commands/dh.test.ts
@@ -1,92 +1,145 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
-import { makeContext, type RawOption } from './lib/context.js'
+import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { DAGGERHEART } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
-const mockRoll = mock(
-  (): { result: string; total: number; details: unknown; rolls: unknown[] } => ({
-    result: 'hope',
-    total: 14,
-    details: { hope: { roll: 8 }, fear: { roll: 6 }, extraDie: undefined, modifier: 0 },
-    rolls: []
-  })
-)
+interface DhResult {
+  result: string
+  total: number
+  details: {
+    hope: { roll: number; amplified: boolean }
+    fear: { roll: number; amplified: boolean }
+    modifier: number
+    extraDie?: { advantageRoll: number; disadvantageRoll: number }
+  }
+  rolls: unknown[]
+}
+
+const withHope = (): DhResult => ({
+  result: 'hope',
+  total: 15,
+  details: {
+    hope: { roll: 9, amplified: false },
+    fear: { roll: 6, amplified: false },
+    modifier: 0
+  },
+  rolls: []
+})
+
+const mockRoll = mock(withHope)
 
 void mock.module('@randsum/games/daggerheart', () => ({ roll: mockRoll }))
 
 const { dhCommand } = await import('../../src/commands/dh.js')
 
-function render(options: readonly RawOption[] = []): APIEmbed {
-  return dhCommand.buildEmbed!(makeContext(options)).toJSON()
-}
-
-function fieldNames(embed: APIEmbed): string[] {
-  return (embed.fields ?? []).map(field => field.name)
+function render(options: { name: string; value: unknown }[] = []): RollView {
+  return dhCommand.buildView!(makeContext(options))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(withHope)
 })
 
 describe('dhCommand', () => {
-  test('hope result', () => {
-    expect(render().title).toBe('Hope!')
+  test("uses the game's own vocabulary, and states the consequence", () => {
+    // "Critical Hope!" is not a Daggerheart term, and the consequence — you
+    // gain a Hope, the GM gains a Fear — was stated nowhere in the old embed.
+    const view = render()
+    expect(textOf(view)).toContain('Rolled with Hope')
+    expect(textOf(view)).toContain('You gain a Hope.')
+    expect(accentsOf(view)[0]).toBe(DAGGERHEART.hope)
   })
 
-  test('fear result', () => {
+  test('a fear result says who gains the metacurrency', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'fear' as const,
-      total: 10,
-      details: { hope: { roll: 4 }, fear: { roll: 8 }, extraDie: undefined, modifier: 0 },
-      rolls: []
+      ...withHope(),
+      result: 'fear',
+      details: { ...withHope().details, hope: { roll: 4, amplified: false } }
     }))
-    expect(render().title).toBe('Fear!')
+    const view = render()
+    expect(textOf(view)).toContain('Rolled with Fear')
+    expect(textOf(view)).toContain('The GM gains a Fear.')
+    expect(accentsOf(view)[0]).toBe(DAGGERHEART.fear)
   })
 
-  test('critical hope result', () => {
+  test('a critical is the game term, and clears a Stress', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'critical_hope' as const,
-      total: 20,
-      details: { hope: { roll: 10 }, fear: { roll: 10 }, extraDie: undefined, modifier: 0 },
-      rolls: []
+      ...withHope(),
+      result: 'critical_hope',
+      total: 20
     }))
-    expect(render().title).toBe('Critical Hope!')
+    const view = render()
+    expect(textOf(view)).toContain('## ✸ Critical Success!')
+    expect(textOf(view)).toContain('clear a Stress')
+    expect(accentsOf(view)[0]).toBe(DAGGERHEART.critical)
   })
 
-  test('with advantage and extraDie shows extra die fields', () => {
+  test('a difficulty renders the OTHER axis of the roll', () => {
+    // Daggerheart resolves on a grid: success-or-failure AND hope-or-fear.
+    // Without a difficulty the bot could only ever show the second, so
+    // "Success with Fear" — the result that most defines the game — looked
+    // identical to a plain failure.
     mockRoll.mockImplementationOnce(() => ({
-      result: 'hope' as const,
-      total: 18,
+      ...withHope(),
+      result: 'fear',
+      total: 16
+    }))
+    expect(textOf(render([{ name: 'difficulty', value: 14 }]))).toContain(
+      'Success with Fear  ·  16 vs DC 14'
+    )
+  })
+
+  test('a failure with fear is distinguishable from a success with fear', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      ...withHope(),
+      result: 'fear',
+      total: 11
+    }))
+    expect(textOf(render([{ name: 'difficulty', value: 14 }]))).toContain(
+      '✕ Failure with Fear  ·  11 vs DC 14'
+    )
+  })
+
+  test('without a difficulty it falls back to the duality axis alone', () => {
+    expect(textOf(render())).not.toContain('vs DC')
+  })
+
+  test('amplified dice are labelled from the engine, not the raw options', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      ...withHope(),
       details: {
-        hope: { roll: 8 },
-        fear: { roll: 6 },
-        extraDie: { roll: 4, advantageRoll: 4, disadvantageRoll: undefined },
-        modifier: 0
-      },
-      rolls: []
+        ...withHope().details,
+        hope: { roll: 17, amplified: true },
+        fear: { roll: 6, amplified: false }
+      }
     }))
-    const embed = render([{ name: 'rolling_with', value: 'Advantage' }])
-    expect(fieldNames(embed)).toContain('Advantage Die (d6)')
+    const text = textOf(render([{ name: 'amplify_hope', value: true }]))
+    expect(text).toContain('Hope d20')
+    expect(text).toContain('Fear d12')
   })
 
-  test('with modifier adds modifier field', () => {
-    expect(fieldNames(render([{ name: 'modifier', value: 3 }]))).toContain('Modifier')
+  test('a disadvantage die is shown signed, because it is subtracted', () => {
+    // The old embed printed "Disadvantage Die (d6): 4" beside a total it had
+    // reduced by 4.
+    mockRoll.mockImplementationOnce(() => ({
+      ...withHope(),
+      details: {
+        ...withHope().details,
+        extraDie: { advantageRoll: 0, disadvantageRoll: 4 }
+      }
+    }))
+    expect(textOf(render([{ name: 'rolling_with', value: 'Disadvantage' }]))).toContain(
+      '**Disadvantage (d6)** -4'
+    )
   })
 
-  test('without modifier omits the modifier field', () => {
-    expect(fieldNames(render())).not.toContain('Modifier')
-  })
-
-  test('amplify options select the d20 die labels', () => {
-    const embed = render([
-      { name: 'amplify_hope', value: true },
-      { name: 'amplify_fear', value: false }
-    ])
-    expect(fieldNames(embed)).toContain('Hope Die (d20)')
-    expect(fieldNames(embed)).toContain('Fear Die (d12)')
+  test('a modifier appears only when non-zero', () => {
+    expect(textOf(render())).not.toContain('**Modifier**')
+    expect(textOf(render([{ name: 'modifier', value: 2 }]))).toContain('**Modifier** +2')
   })
 
   test('error path: a failing roll propagates', () => {
-    // The dispatcher renders the "Error" embed — see dispatch.test.ts.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })

--- a/apps/discord-bot/__tests__/commands/fate.test.ts
+++ b/apps/discord-bot/__tests__/commands/fate.test.ts
@@ -1,61 +1,120 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
-import { makeContext, type RawOption } from './lib/context.js'
+import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { FATE } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
-const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
-  result: 'great',
-  total: 4,
-  rolls: [{ initialRolls: [1, 1, 0, 1], rolls: [1, 1, 0, 1], modifierLogs: [] }]
-}))
+const good = (): { result: string; total: number; rolls: unknown[] } => ({
+  result: 'good',
+  total: 3,
+  rolls: [{ initialRolls: [1, 0, -1, 1], rolls: [1, 0, -1, 1], modifierLogs: [] }]
+})
+
+const mockRoll = mock(good)
 
 void mock.module('@randsum/games/fate', () => ({ roll: mockRoll }))
 
 const { fateCommand } = await import('../../src/commands/fate.js')
 
-function render(options: readonly RawOption[] = []): APIEmbed {
-  return fateCommand.buildEmbed!(makeContext(options)).toJSON()
-}
-
-function field(embed: APIEmbed, name: string): { name: string; value: string } | undefined {
-  return (embed.fields ?? []).find(entry => entry.name === name)
+function render(options: { name: string; value: unknown }[] = []): RollView {
+  return fateCommand.buildView!(makeContext(options))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(good)
 })
 
 describe('fateCommand', () => {
-  test('titles the embed with the ladder rung', () => {
-    expect(render().title).toBe('Great')
+  test('the headline is the ladder rung and its number', () => {
+    // The ladder is a number line, so the rung alone loses half the meaning.
+    const view = render()
+    expect(textOf(view)).toContain('## Good (+3)')
+    expect(accentsOf(view)[0]).toBe(FATE.good)
   })
 
-  test('renders the four Fate dice symbols', () => {
-    expect(field(render(), 'Fate Dice (4dF)')?.value).toBe('+  +  ▢  +')
+  test('Fate dice render as monospace tiles, not a tofu-prone glyph', () => {
+    // The old renderer used ▢ (U+25A2), which has patchy font coverage and
+    // rendered as tofu on some Android and Linux configurations.
+    const text = textOf(render())
+    expect(text).toContain('`[+]`')
+    expect(text).toContain('`[ ]`')
+    expect(text).toContain('`[-]`')
+    expect(text).not.toContain('▢')
   })
 
-  test('non-zero skill adds a skill field', () => {
-    expect(field(render([{ name: 'skill', value: 3 }]), 'Skill')?.value).toBe('+3')
+  test('opposition resolves shifts into a real Fate outcome', () => {
+    // Fate's actual outcomes are Fail / Tie / Success / Succeed with Style,
+    // measured in shifts. A bare ladder rung tells a Fate player nothing.
+    expect(textOf(render([{ name: 'opposition', value: 0 }]))).toContain('Succeed with Style')
+    expect(textOf(render([{ name: 'opposition', value: 2 }]))).toContain('Success')
+    expect(textOf(render([{ name: 'opposition', value: 3 }]))).toContain('Tie')
+    expect(textOf(render([{ name: 'opposition', value: 5 }]))).toContain('Fail')
   })
 
-  test('zero skill omits the skill field', () => {
-    expect(field(render([{ name: 'skill', value: 0 }]), 'Skill')).toBeUndefined()
+  test('a tie is described as a tie, not as "0 shifts over"', () => {
+    expect(textOf(render([{ name: 'opposition', value: 3 }]))).toContain('A tie')
   })
 
-  test('clamps an out-of-range skill to the ladder bounds', () => {
+  test('shift counts are singular or plural as appropriate', () => {
+    expect(textOf(render([{ name: 'opposition', value: 2 }]))).toContain('1 shift over')
+    expect(textOf(render([{ name: 'opposition', value: 0 }]))).toContain('3 shifts over')
+  })
+
+  test('without opposition the rung stands alone, with no invented outcome', () => {
+    const text = textOf(render())
+    expect(text).not.toContain('Succeed with Style')
+    expect(text).not.toContain('shift')
+  })
+
+  test('a skill appears only when non-zero', () => {
+    expect(textOf(render())).not.toContain('**Skill**')
+    expect(textOf(render([{ name: 'skill', value: 2 }]))).toContain('**Skill** +2')
+  })
+
+  test('an out-of-range skill is clamped to the ladder bounds', () => {
     render([{ name: 'skill', value: 99 }])
     expect(mockRoll).toHaveBeenCalledWith({ modifier: 5 })
-  })
 
-  test('clamps a below-range skill to the ladder floor', () => {
     render([{ name: 'skill', value: -99 }])
-    expect(mockRoll).toHaveBeenCalledWith({ modifier: -2 })
+    expect(mockRoll).toHaveBeenLastCalledWith({ modifier: -2 })
   })
 
   test('error path: a failing roll propagates', () => {
-    // The dispatcher renders the "Error" embed — see dispatch.test.ts.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })
-    expect(() => render([{ name: 'skill', value: 1 }])).toThrow('Test error')
+    expect(() => render()).toThrow('Test error')
+  })
+
+  test('the accent follows the outcome, not the ladder rung', () => {
+    // A Legendary total against stiffer opposition is still a Fail, and the
+    // accent used to come from the rung — so a failure rendered gold while the
+    // word beside it read "Fail". palette.ts promises the accent lets a player
+    // read success-versus-failure before any text; for this path it lied.
+    mockRoll.mockImplementationOnce(() => ({
+      result: 'legendary',
+      total: 8,
+      rolls: [{ initialRolls: [1, 1, 1, 0], rolls: [1, 1, 1, 0], modifierLogs: [] }]
+    }))
+    const view = render([{ name: 'opposition', value: 10 }])
+    expect(textOf(view)).toContain('Fail')
+    expect(accentsOf(view)[0]).toBe(FATE.terrible)
+    expect(accentsOf(view)[0]).not.toBe(FATE.legendary)
+  })
+
+  test('a low rung that beats weak opposition is not painted as a failure', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 'poor',
+      total: -1,
+      rolls: [{ initialRolls: [-1, 0, 0, 0], rolls: [-1, 0, 0, 0], modifierLogs: [] }]
+    }))
+    const view = render([{ name: 'opposition', value: -4 }])
+    expect(textOf(view)).toContain('Succeed with Style')
+    expect(accentsOf(view)[0]).toBe(FATE.legendary)
+  })
+
+  test('without opposition the rung still drives the accent', () => {
+    // No verdict to report, so the ladder is all there is.
+    expect(accentsOf(render())[0]).toBe(FATE.good)
   })
 })

--- a/apps/discord-bot/__tests__/commands/fifth.test.ts
+++ b/apps/discord-bot/__tests__/commands/fifth.test.ts
@@ -1,129 +1,162 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
-import { makeContext, type RawOption } from './lib/context.js'
+import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { FIFTH } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
-const mockRoll = mock(
-  (): { total: number; result: number; rolls: unknown[]; details: unknown } => ({
-    total: 15,
-    result: 15,
-    rolls: [{ initialRolls: [15], rolls: [15], modifierLogs: [] }],
-    details: { criticals: undefined }
-  })
-)
+interface FifthResult {
+  result: number
+  total: number
+  details: { criticals?: { isNatural1: boolean; isNatural20: boolean } }
+  rolls: unknown[]
+}
+
+const plain = (): FifthResult => ({
+  result: 12,
+  total: 12,
+  details: { criticals: { isNatural1: false, isNatural20: false } },
+  rolls: [{ initialRolls: [12], rolls: [12], modifierLogs: [] }]
+})
+
+const mockRoll = mock(plain)
 
 void mock.module('@randsum/games/fifth', () => ({ roll: mockRoll }))
 
 const { fifthCommand } = await import('../../src/commands/fifth.js')
 
-function render(options: readonly RawOption[] = []): APIEmbed {
-  return fifthCommand.buildEmbed!(makeContext(options)).toJSON()
-}
-
-function diceValue(embed: APIEmbed, name: string): string | undefined {
-  return (embed.fields ?? []).find(field => field.name === name)?.value
+function render(options: { name: string; value: unknown }[] = []): RollView {
+  return fifthCommand.buildView!(makeContext(options))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(plain)
 })
 
 describe('fifthCommand', () => {
-  test('normal roll uses blue color', () => {
-    const embed = render()
-    expect(embed.color).toBe(0x1e90ff)
-    expect(embed.title).toBe('D&D 5e Roll: 15')
+  test('the total leads, and the system name is not repeated back', () => {
+    // 5e is the one game where the raw number genuinely is the headline —
+    // bounded accuracy makes the whole resolution "compare this to a DC". The
+    // old title spent its loudest characters on "D&D 5e Roll:", which the
+    // player had just typed.
+    const view = render()
+    expect(textOf(view)).toContain('## 12')
+    expect(textOf(view)).not.toContain('D&D')
+    expect(accentsOf(view)[0]).toBe(FIFTH.standard)
   })
 
-  test('passes crit: true in the roll call', () => {
-    render([{ name: 'modifier', value: 3 }])
-    expect(mockRoll).toHaveBeenCalledWith({ modifier: 3, crit: true })
+  test('a natural 20 is marked, and worded truly for both rules editions', () => {
+    // Under the 2014 rules a nat 20 auto-hits on ATTACK ROLLS only, not on
+    // checks or saves; 2024 changed that. "Critical hit on an attack roll" is
+    // true under both, where a bare "automatic success" would not be.
+    mockRoll.mockImplementationOnce(() => ({
+      result: 20,
+      total: 20,
+      details: { criticals: { isNatural1: false, isNatural20: true } },
+      rolls: [{ initialRolls: [20], rolls: [20], modifierLogs: [] }]
+    }))
+    const view = render()
+    expect(textOf(view)).toContain('## ✸ Natural 20  ·  20')
+    expect(textOf(view)).toContain('Critical hit on an attack roll.')
+    expect(accentsOf(view)[0]).toBe(FIFTH.natural20)
   })
 
-  test('passes crit: true with rollingWith advantage', () => {
-    render([
-      { name: 'modifier', value: 2 },
-      { name: 'rolling_with', value: 'Advantage' }
-    ])
-    expect(mockRoll).toHaveBeenCalledWith({
-      modifier: 2,
-      crit: true,
-      rollingWith: 'Advantage'
-    })
+  test('a natural 1 gets the fumble glyph and its own colour', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 1,
+      total: 1,
+      details: { criticals: { isNatural1: true, isNatural20: false } },
+      rolls: [{ initialRolls: [1], rolls: [1], modifierLogs: [] }]
+    }))
+    const view = render()
+    expect(textOf(view)).toContain('## ☠ Natural 1  ·  1')
+    expect(accentsOf(view)[0]).toBe(FIFTH.natural1)
   })
 
-  test('passes crit: true with rollingWith disadvantage', () => {
+  test('a dc resolves the roll instead of leaving the player to compare', () => {
+    expect(textOf(render([{ name: 'dc', value: 10 }]))).toContain('Success vs DC 10')
+    expect(textOf(render([{ name: 'dc', value: 15 }]))).toContain('Failure vs DC 15')
+  })
+
+  test('no dc means no comparison line, not a wrong one', () => {
+    expect(textOf(render())).not.toContain('vs DC')
+  })
+
+  test('advantage marks the kept die bold and the dropped die struck', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 18,
+      total: 18,
+      details: { criticals: { isNatural1: false, isNatural20: false } },
+      rolls: [{ initialRolls: [18, 4], rolls: [18], modifierLogs: [] }]
+    }))
+    const text = textOf(render([{ name: 'rolling_with', value: 'Advantage' }]))
+    expect(text).toContain('**2d20, Advantage**')
+    expect(text).toContain('**18**')
+    expect(text).toContain('~~4~~')
+  })
+
+  test('a tie marks exactly one die kept and one dropped, not both bold', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 9,
+      total: 9,
+      details: { criticals: { isNatural1: false, isNatural20: false } },
+      rolls: [{ initialRolls: [9, 9], rolls: [9], modifierLogs: [] }]
+    }))
+    const text = textOf(render([{ name: 'rolling_with', value: 'Advantage' }]))
+    expect(text).toContain('**9**, ~~9~~')
+  })
+
+  test('passes crit: true so the roller reports naturals', () => {
+    render()
+    expect(mockRoll).toHaveBeenCalledWith({ modifier: 0, crit: true })
+
     render([{ name: 'rolling_with', value: 'Disadvantage' }])
-    expect(mockRoll).toHaveBeenCalledWith({
+    expect(mockRoll).toHaveBeenLastCalledWith({
       modifier: 0,
       crit: true,
       rollingWith: 'Disadvantage'
     })
   })
 
-  test('natural 20 uses gold color and "Natural 20!" prefix', () => {
-    mockRoll.mockImplementationOnce(() => ({
-      total: 20,
-      result: 20,
-      rolls: [{ initialRolls: [20], rolls: [20], modifierLogs: [] }],
-      details: { criticals: { isNatural20: true, isNatural1: false } }
-    }))
-    const embed = render()
-    expect(embed.color).toBe(0xffd700)
-    expect(embed.title).toBe('Natural 20! D&D 5e Roll: 20')
-  })
-
-  test('natural 1 uses crimson color and "Natural 1!" prefix', () => {
-    mockRoll.mockImplementationOnce(() => ({
-      total: 1,
-      result: 1,
-      rolls: [{ initialRolls: [1], rolls: [1], modifierLogs: [] }],
-      details: { criticals: { isNatural20: false, isNatural1: true } }
-    }))
-    const embed = render()
-    expect(embed.color).toBe(0xdc143c)
-    expect(embed.title).toBe('Natural 1! D&D 5e Roll: 1')
-  })
-
-  test('advantage tie: kept die bold, dropped die struck (not both bold)', () => {
-    // Both d20s show 4. The roller keeps one (rolls: [4]); the display must
-    // bold exactly one die and strike the other, never bold both.
-    mockRoll.mockImplementationOnce(() => ({
-      total: 4,
-      result: 4,
-      rolls: [{ initialRolls: [4, 4], rolls: [4], modifierLogs: [] }],
-      details: { criticals: undefined }
-    }))
-    const embed = render([{ name: 'rolling_with', value: 'Advantage' }])
-    expect(diceValue(embed, 'Dice Rolled (2d20)')).toBe('**4**, ~~4~~')
-  })
-
-  test('disadvantage tie: kept die bold, dropped die struck (not both bold)', () => {
-    mockRoll.mockImplementationOnce(() => ({
-      total: 17,
-      result: 17,
-      rolls: [{ initialRolls: [17, 17], rolls: [17], modifierLogs: [] }],
-      details: { criticals: undefined }
-    }))
-    const embed = render([{ name: 'rolling_with', value: 'Disadvantage' }])
-    expect(diceValue(embed, 'Dice Rolled (2d20)')).toBe('**17**, ~~17~~')
-  })
-
-  test('advantage non-tie: higher kept bold, lower struck', () => {
-    mockRoll.mockImplementationOnce(() => ({
-      total: 18,
-      result: 18,
-      rolls: [{ initialRolls: [18, 5], rolls: [18], modifierLogs: [] }],
-      details: { criticals: undefined }
-    }))
-    const embed = render([{ name: 'rolling_with', value: 'Advantage' }])
-    expect(diceValue(embed, 'Dice Rolled (2d20)')).toBe('**18**, ~~5~~')
-  })
-
   test('error path: a failing roll propagates', () => {
-    // The dispatcher renders the "Error" embed — see dispatch.test.ts.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })
     expect(() => render()).toThrow('Test error')
+  })
+
+  test('a natural 1 that still clears the DC reads as a success, not a fumble', () => {
+    // The two-axis bug: a nat 1 on a +30 modifier totals 31 and beats DC 10.
+    // Rendering ☠ in fumble red over the word "Success" said the opposite of
+    // the line beneath it — the same mistake as labelling a kept-lowest die
+    // "Highest Roll". The natural is still announced, because it changes what
+    // the roll means; it just no longer decides the colour.
+    mockRoll.mockImplementationOnce(() => ({
+      result: 31,
+      total: 31,
+      details: { criticals: { isNatural1: true, isNatural20: false } },
+      rolls: [{ initialRolls: [1], rolls: [1], modifierLogs: [] }]
+    }))
+    const view = render([
+      { name: 'modifier', value: 30 },
+      { name: 'dc', value: 10 }
+    ])
+    expect(textOf(view)).toContain('## ◆ Natural 1  ·  31')
+    expect(textOf(view)).toContain('Success vs DC 10')
+    expect(accentsOf(view)[0]).toBe(FIFTH.natural20)
+  })
+
+  test('a natural 20 that misses the DC reads as a failure', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 15,
+      total: 15,
+      details: { criticals: { isNatural1: false, isNatural20: true } },
+      rolls: [{ initialRolls: [20], rolls: [20], modifierLogs: [] }]
+    }))
+    const view = render([
+      { name: 'modifier', value: -5 },
+      { name: 'dc', value: 30 }
+    ])
+    expect(textOf(view)).toContain('## ✕ Natural 20  ·  15')
+    expect(accentsOf(view)[0]).toBe(FIFTH.natural1)
   })
 })

--- a/apps/discord-bot/__tests__/commands/pbta.test.ts
+++ b/apps/discord-bot/__tests__/commands/pbta.test.ts
@@ -1,68 +1,75 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
-import { makeContext, type RawOption } from './lib/context.js'
+import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { PBTA } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
-const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
+interface PbtaResult {
+  result: string
+  total: number
+  details: { diceTotal: number }
+  rolls: unknown[]
+}
+
+const strongHit = (): PbtaResult => ({
   result: 'strong_hit',
   total: 10,
-  rolls: [{ initialRolls: [5, 5], rolls: [5, 5], modifierLogs: [] }]
-}))
+  details: { diceTotal: 8 },
+  rolls: [{ initialRolls: [4, 4], rolls: [4, 4], modifierLogs: [] }]
+})
+
+const mockRoll = mock(strongHit)
 
 void mock.module('@randsum/games/pbta', () => ({ roll: mockRoll }))
 
 const { pbtaCommand } = await import('../../src/commands/pbta.js')
 
-function render(options: readonly RawOption[] = [{ name: 'stat', value: 2 }]): APIEmbed {
-  return pbtaCommand.buildEmbed!(makeContext(options)).toJSON()
-}
-
-function fieldNames(embed: APIEmbed): string[] {
-  return (embed.fields ?? []).map(field => field.name)
+function render(options: { name: string; value: unknown }[]): RollView {
+  return pbtaCommand.buildView!(makeContext(options))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(strongHit)
 })
 
 describe('pbtaCommand', () => {
-  test('strong hit', () => {
-    expect(render().title).toBe('Strong Hit!')
+  test('the numeric band leads, the name follows', () => {
+    // PbtA is a family, not a game: "10+" travels to every table running one
+    // of them, where "strong hit" is Dungeon World's word specifically.
+    const view = render([{ name: 'stat', value: 2 }])
+    expect(textOf(view)).toContain('## ◆ 10+  ·  Strong Hit')
+    expect(accentsOf(view)[0]).toBe(PBTA.strongHit)
   })
 
-  test('weak hit', () => {
+  test('a weak hit names the cost', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'weak_hit' as const,
+      result: 'weak_hit',
       total: 8,
-      rolls: [{ initialRolls: [4, 4], rolls: [4, 4], modifierLogs: [] }]
+      details: { diceTotal: 6 },
+      rolls: [{ initialRolls: [3, 3], rolls: [3, 3], modifierLogs: [] }]
     }))
-    expect(render([{ name: 'stat', value: 1 }]).title).toBe('Weak Hit')
+    const view = render([{ name: 'stat', value: 2 }])
+    expect(textOf(view)).toContain('## ◈ 7-9  ·  Weak Hit')
+    expect(accentsOf(view)[0]).toBe(PBTA.weakHit)
   })
 
-  test('miss', () => {
+  test('a miss reminds the player to mark experience', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'miss' as const,
-      total: 4,
-      rolls: [{ initialRolls: [2, 2], rolls: [2, 2], modifierLogs: [] }]
+      result: 'miss',
+      total: 5,
+      details: { diceTotal: 3 },
+      rolls: [{ initialRolls: [1, 2], rolls: [1, 2], modifierLogs: [] }]
     }))
-    expect(render([{ name: 'stat', value: -1 }]).title).toBe('Miss')
+    const view = render([{ name: 'stat', value: 2 }])
+    expect(textOf(view)).toContain('## ✕ 6-  ·  Miss')
+    expect(textOf(view)).toContain('mark experience')
+    expect(accentsOf(view)[0]).toBe(PBTA.miss)
   })
 
-  test('non-zero forward adds forward field', () => {
-    const embed = render([
-      { name: 'stat', value: 2 },
-      { name: 'forward', value: 1 }
-    ])
-    expect(fieldNames(embed)).toContain('Forward')
-    expect(mockRoll).toHaveBeenCalledWith({ stat: 2, forward: 1 })
-  })
-
-  test('non-zero ongoing adds ongoing field', () => {
-    const embed = render([
-      { name: 'stat', value: 2 },
-      { name: 'ongoing', value: 2 }
-    ])
-    expect(fieldNames(embed)).toContain('Ongoing')
-    expect(mockRoll).toHaveBeenCalledWith({ stat: 2, ongoing: 2 })
+  test('the dice-only subtotal is shown beside the modifiers', () => {
+    // `details.diceTotal` is computed on every roll and was never rendered —
+    // it is exactly the number a PbtA player wants next to their stat.
+    expect(textOf(render([{ name: 'stat', value: 2 }]))).toContain('**Dice** 8')
   })
 
   test('rollingWith is forwarded under the key the roller accepts', () => {
@@ -70,25 +77,54 @@ describe('pbtaCommand', () => {
     // the generated roller does not declare. A conditional spread dodges
     // excess-property checking, so it compiled, was silently dropped, and the
     // embed reported advantage over a plain 2d6.
-    const embed = render([
+    render([
       { name: 'stat', value: 2 },
       { name: 'rolling_with', value: 'Advantage' }
     ])
-    expect(fieldNames(embed)).toContain('Rolling With')
     expect(mockRoll).toHaveBeenCalledWith({ stat: 2, rollingWith: 'Advantage' })
   })
 
+  test('a kept-two pool names the mechanic and marks the dropped die', () => {
+    mockRoll.mockImplementationOnce(() => ({
+      result: 'strong_hit',
+      total: 12,
+      details: { diceTotal: 10 },
+      rolls: [{ initialRolls: [2, 4, 6], rolls: [4, 6], modifierLogs: [] }]
+    }))
+    const text = textOf(
+      render([
+        { name: 'stat', value: 2 },
+        { name: 'rolling_with', value: 'Advantage' }
+      ])
+    )
+    expect(text).toContain('**3d6, keep best 2**')
+    expect(text).toContain('~~2~~')
+  })
+
+  test('forward and ongoing appear only when non-zero', () => {
+    const without = textOf(render([{ name: 'stat', value: 2 }]))
+    expect(without).not.toContain('Forward')
+    expect(without).not.toContain('Ongoing')
+
+    const withBoth = textOf(
+      render([
+        { name: 'stat', value: 2 },
+        { name: 'forward', value: 1 },
+        { name: 'ongoing', value: -1 }
+      ])
+    )
+    expect(withBoth).toContain('**Forward** +1')
+    expect(withBoth).toContain('**Ongoing** -1')
+  })
+
   test('a negative stat renders with its sign', () => {
-    const embed = render([{ name: 'stat', value: -1 }])
-    const stat = (embed.fields ?? []).find(field => field.name === 'Stat')
-    expect(stat?.value).toBe('-1')
+    expect(textOf(render([{ name: 'stat', value: -1 }]))).toContain('**Stat** -1')
   })
 
   test('error path: a failing roll propagates', () => {
-    // The dispatcher renders the "Error" embed — see dispatch.test.ts.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })
-    expect(() => render()).toThrow('Test error')
+    expect(() => render([{ name: 'stat', value: 1 }])).toThrow('Test error')
   })
 })

--- a/apps/discord-bot/__tests__/commands/root.test.ts
+++ b/apps/discord-bot/__tests__/commands/root.test.ts
@@ -1,69 +1,86 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
-import { makeContext, type RawOption } from './lib/context.js'
+import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { ROOT } from '../../src/utils/palette.js'
+import type { RollView } from '../../src/types.js'
 
-const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
+const strongHit = (): { result: string; total: number; rolls: unknown[] } => ({
   result: 'strong_hit',
-  total: 9,
-  rolls: [{ initialRolls: [5, 4], rolls: [5, 4], modifierLogs: [] }]
-}))
+  total: 10,
+  rolls: [{ initialRolls: [5, 5], rolls: [5, 5], modifierLogs: [] }]
+})
+
+const mockRoll = mock(strongHit)
 
 void mock.module('@randsum/games/root-rpg', () => ({ roll: mockRoll }))
 
 const { rootCommand } = await import('../../src/commands/root.js')
 
-function render(options: readonly RawOption[] = [], displayName = 'Tester'): APIEmbed {
-  return rootCommand.buildEmbed!(makeContext(options, displayName)).toJSON()
+function render(options: { name: string; value: unknown }[] = []): RollView {
+  return rootCommand.buildView!(makeContext(options))
 }
 
 beforeEach(() => {
-  mockRoll.mockClear()
+  mockRoll.mockReset().mockImplementation(strongHit)
 })
 
 describe('rootCommand', () => {
-  test('Strong Hit', () => {
-    expect(render().title).toBe('Tester rolled a Strong Hit')
+  test('the band leads, as it does for every PbtA-family game', () => {
+    const view = render([{ name: 'modifier', value: 1 }])
+    expect(textOf(view)).toContain('## ◆ 10+  ·  Strong Hit')
+    expect(accentsOf(view)[0]).toBe(ROOT.strongHit)
   })
 
-  test('Weak Hit', () => {
+  test('a weak hit and a miss are distinct in word and colour', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'weak_hit' as const,
-      total: 7,
-      rolls: [{ initialRolls: [4, 3], rolls: [4, 3], modifierLogs: [] }]
+      result: 'weak_hit',
+      total: 8,
+      rolls: [{ initialRolls: [4, 4], rolls: [4, 4], modifierLogs: [] }]
     }))
-    expect(render().title).toBe('Tester rolled a Weak Hit')
-  })
+    expect(accentsOf(render())[0]).toBe(ROOT.weakHit)
 
-  test('Miss', () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'miss' as const,
-      total: 3,
-      rolls: [{ initialRolls: [2, 1], rolls: [2, 1], modifierLogs: [] }]
+      result: 'miss',
+      total: 4,
+      rolls: [{ initialRolls: [2, 2], rolls: [2, 2], modifierLogs: [] }]
     }))
-    expect(render().title).toBe('Tester rolled a Miss')
+    const miss = render()
+    expect(textOf(miss)).toContain('## ✕ 6-  ·  Miss')
+    expect(accentsOf(miss)[0]).toBe(ROOT.miss)
   })
 
-  test('titles with the display name the transport supplies', () => {
-    // /root is the only command that reads `userDisplayName`, so this is the
-    // one place the context's second field is load-bearing. The Worker resolves
-    // it from the interaction payload (guild `member.user` or DM `user`).
-    expect(render([], 'Vagabond').title).toBe('Vagabond rolled a Strong Hit')
+  test('the roller is not named in the headline', () => {
+    // Discord already renders "<username> used /root" directly above every
+    // response. The old title repeated it, and made this the one command whose
+    // title shape differed from its nine siblings.
+    expect(textOf(render([{ name: 'modifier', value: 1 }]))).not.toContain('Adventurer')
   })
 
-  test('non-zero modifier adds modifier field', () => {
-    const embed = render([{ name: 'modifier', value: 2 }])
-    expect((embed.fields ?? []).map(field => field.name)).toContain('Modifier')
-    expect(mockRoll).toHaveBeenCalledWith({ bonus: 2 })
+  test('a named stat reads back the way a player says it out loud', () => {
+    const text = textOf(
+      render([
+        { name: 'modifier', value: 2 },
+        { name: 'stat', value: 'Cunning' }
+      ])
+    )
+    expect(text).toContain('Strong Hit  ·  Cunning')
+    expect(text).toContain('**Cunning** +2')
   })
 
-  test('an absent modifier defaults to zero and omits the field', () => {
-    const embed = render()
-    expect((embed.fields ?? []).map(field => field.name)).not.toContain('Modifier')
-    expect(mockRoll).toHaveBeenCalledWith({ bonus: 0 })
+  test('without a stat name the modifier is still labelled', () => {
+    expect(textOf(render([{ name: 'modifier', value: 2 }]))).toContain('**Modifier** +2')
+  })
+
+  test('rollingWith is forwarded to the roller the spec supports', () => {
+    // The spec has always supported this; the command exposed no option for it.
+    render([
+      { name: 'modifier', value: 1 },
+      { name: 'rolling_with', value: 'Advantage' }
+    ])
+    expect(mockRoll).toHaveBeenCalledWith({ bonus: 1, rollingWith: 'Advantage' })
   })
 
   test('error path: a failing roll propagates', () => {
-    // The dispatcher renders the "Error" embed — see dispatch.test.ts.
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')
     })

--- a/apps/discord-bot/src/commands/blades.ts
+++ b/apps/discord-bot/src/commands/blades.ts
@@ -1,73 +1,74 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/blades'
-import { embedFooterDetails } from '../utils/constants.js'
-import { createGameCommand, getInitialRolls, getKeptRolls, markKeptRolls } from './lib/index.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { BLADES, GLYPH } from '../utils/palette.js'
+import {
+  createGameCommand,
+  getInitialRolls,
+  getKeptRolls,
+  markKeptRolls,
+  rollContainer
+} from './lib/index.js'
 import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import type { Command, RollView } from '../types.js'
 
-function buildBladesEmbed(context: CommandContext): EmbedBuilder {
+/**
+ * Outcome copy in Blades' own register.
+ *
+ * The old strings were generic — "Success!", "You succeed at your goal" — where
+ * the book is blunt and specific. A 6 is "you do it"; a 4-5 is "you do it, but";
+ * a 1-3 is "things go badly".
+ */
+const OUTCOMES = {
+  critical: {
+    accent: BLADES.critical,
+    headline: `${GLYPH.critical} Critical`,
+    consequence: 'You do it, and you get increased effect.'
+  },
+  success: {
+    accent: BLADES.success,
+    headline: `${GLYPH.success} Full Success`,
+    consequence: 'You do it.'
+  },
+  partial: {
+    accent: BLADES.partial,
+    headline: `${GLYPH.mixed} Partial Success`,
+    consequence: "You do it, but there's a consequence."
+  },
+  failure: {
+    accent: BLADES.failure,
+    headline: `${GLYPH.failure} Bad Outcome`,
+    consequence: 'Things go badly. The GM says how it gets worse.'
+  }
+} as const
+
+function buildBladesView(context: CommandContext): RollView {
   const dice = context.options.getInteger('dice', true)
   const result = roll({ rating: dice })
 
   const initialRolls = getInitialRolls(result)
-  // The die the engine kept, not a locally recomputed maximum. At rating 0 the
-  // roller keeps the *lowest* of two dice, so `Math.max` named — and bolded —
-  // the die that was thrown away, directly contradicting the outcome title.
   const keptRolls = getKeptRolls(result)
   const decidingDie = keptRolls[0] ?? result.total
+  const outcome = OUTCOMES[result.result]
 
-  const resultConfig = {
-    critical: {
-      color: 0xffd700,
-      resultTitle: 'Critical Success!',
-      resultDescription: 'Things go better than expected'
-    },
-    success: {
-      color: 0x00ff00,
-      resultTitle: 'Success!',
-      resultDescription: 'You succeed at your goal'
-    },
-    partial: {
-      color: 0xffff00,
-      resultTitle: 'Partial Success',
-      resultDescription: 'You succeed, but with a consequence'
-    },
-    failure: {
-      color: 0xff0000,
-      resultTitle: 'Failure',
-      resultDescription: "Things don't go your way"
-    }
-  }
+  // At rating 0 the roller keeps the *lowest* of two dice. "Deciding Die" is
+  // correct in both branches, where "Highest Roll" was wrong in one of them.
+  const pool =
+    dice === 0 ? '0 dice — roll two, take the worst' : `${dice} ${dice === 1 ? 'die' : 'dice'}`
 
-  const { color, resultTitle, resultDescription } = resultConfig[result.result]
-
-  const embed = new EmbedBuilder()
-    .setColor(color)
-    .setTitle(resultTitle)
-    .setDescription(resultDescription)
-    .setFooter(embedFooterDetails)
-
-  embed.addFields({
-    name: 'Dice Pool',
-    value: dice === 0 ? '0 dice (rolled 2, taking lowest)' : `${dice} dice`,
-    inline: true
-  })
-
-  embed.addFields({
-    name: 'Deciding Die',
-    value: String(decidingDie),
-    inline: true
-  })
-
-  const rollsText = markKeptRolls(initialRolls, keptRolls)
-
-  embed.addFields({
-    name: 'All Rolls',
-    value: rollsText || 'None',
-    inline: false
-  })
-
-  return embed
+  return [
+    rollContainer({
+      accent: outcome.accent,
+      headline: outcome.headline,
+      consequence: outcome.consequence,
+      facts: [
+        { label: 'Pool', value: pool },
+        { label: 'Deciding Die', value: String(decidingDie) }
+      ],
+      body: [markKeptRolls(initialRolls, keptRolls)],
+      derivation: `${initialRolls.length}d6 → ${decidingDie}`,
+      rerollId: `r:blades:${dice}`
+    })
+  ]
 }
 
 export const bladesCommand: Command = createGameCommand({
@@ -77,7 +78,7 @@ export const bladesCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('dice')
-        .setDescription('Number of dice to roll (0-10)')
+        .setDescription('Dice pool size (0 = roll two, take the worst)')
         .setRequired(true)
         .setMinValue(0)
         .setMaxValue(10)
@@ -88,5 +89,5 @@ export const bladesCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildBladesEmbed
+  buildView: buildBladesView
 })

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -1,12 +1,28 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/daggerheart'
-import { embedFooterDetails } from '../utils/constants.js'
-import { createGameCommand, formatSignedModifier } from './lib/index.js'
-import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { DAGGERHEART, GLYPH } from '../utils/palette.js'
+import { createGameCommand, formatSignedModifier, rollContainer } from './lib/index.js'
+import type { CommandContext, ViewFact } from './lib/index.js'
+import type { Command, RollView } from '../types.js'
 
-function buildDhEmbed(context: CommandContext): EmbedBuilder {
+/**
+ * `/dh` — Daggerheart, which resolves on a **grid**, not a line.
+ *
+ * A Daggerheart roll produces two independent facts: whether you succeeded
+ * (total vs Difficulty) and who gains metacurrency (Hope vs Fear). Without a
+ * `difficulty` the bot can only ever render the second, so "Success with Fear"
+ * — the result that most defines the game — looked identical to a plain
+ * failure. `difficulty` is optional: absent it, the headline falls back to the
+ * Hope/Fear axis alone.
+ *
+ * The old copy was also not the game's. "Critical Hope!" is not a Daggerheart
+ * term; the game says Critical Success, Rolled with Hope, Rolled with Fear. And
+ * the consequence — you gain a Hope, the GM gains a Fear, a crit also clears a
+ * Stress — was stated nowhere.
+ */
+function buildDhView(context: CommandContext): RollView {
   const modifier = context.options.getInteger('modifier') ?? 0
+  const difficulty = context.options.getInteger('difficulty')
   const rollingWith = context.options.getString('rolling_with') as
     | 'Advantage'
     | 'Disadvantage'
@@ -21,53 +37,63 @@ function buildDhEmbed(context: CommandContext): EmbedBuilder {
     amplifyFear
   })
 
-  const color: number =
-    result.result === 'critical_hope' ? 0xffd700 : result.result === 'hope' ? 0xffff00 : 0x9b59b6
+  const isCritical = result.result === 'critical_hope'
+  const withHope = result.result === 'hope'
+  const accent = isCritical ? DAGGERHEART.critical : withHope ? DAGGERHEART.hope : DAGGERHEART.fear
 
-  const embed = new EmbedBuilder()
-    .setColor(color)
-    .setTitle(
-      `${result.result === 'critical_hope' ? 'Critical ' : ''}${result.result === 'fear' ? 'Fear' : 'Hope'}!`
-    )
-    .setDescription(`Total: ${result.total}`)
-    .setFooter(embedFooterDetails)
+  const succeeded = difficulty !== null ? result.total >= difficulty : null
 
-  const hopeDie = result.details.hope.roll
-  embed.addFields({
-    name: `Hope Die (${amplifyHope ? 'd20' : 'd12'})`,
-    value: String(hopeDie),
-    inline: true
-  })
+  const headline = ((): string => {
+    if (isCritical) return `${GLYPH.critical} Critical Success!`
+    const duality = withHope ? 'with Hope' : 'with Fear'
+    if (succeeded === null) return `${withHope ? GLYPH.success : GLYPH.mixed} Rolled ${duality}`
+    const glyph = succeeded ? GLYPH.success : GLYPH.failure
+    return `${glyph} ${succeeded ? 'Success' : 'Failure'} ${duality}  ·  ${result.total} vs DC ${difficulty}`
+  })()
 
-  const fearDie = result.details.fear.roll
-  embed.addFields({
-    name: `Fear Die (${amplifyFear ? 'd20' : 'd12'})`,
-    value: String(fearDie),
-    inline: true
-  })
+  const consequence = ((): string => {
+    if (isCritical) {
+      return 'Matching Duality Dice. You succeed, you gain a Hope, and you clear a Stress.'
+    }
+    if (withHope) return 'You gain a Hope.'
+    return 'The GM gains a Fear.'
+  })()
 
-  if (modifier !== 0) {
-    embed.addFields({
-      name: 'Modifier',
-      value: formatSignedModifier(modifier),
-      inline: true
-    })
-  }
+  // `details.hope.amplified` / `details.fear.amplified` come from the engine
+  // rather than being re-derived from the raw option flags.
+  const hopeSides = result.details.hope.amplified ? 'd20' : 'd12'
+  const fearSides = result.details.fear.amplified ? 'd20' : 'd12'
+
+  // The dice themselves live in the body, as they do for every other command;
+  // facts carry the modifiers and the total.
+  const facts: ViewFact[] = []
 
   if (rollingWith && result.details.extraDie) {
-    const dieRoll =
+    // A disadvantage die is SUBTRACTED by the engine, but the old embed printed
+    // it unsigned — "Disadvantage Die (d6): 4" beside a total it had reduced.
+    const extra =
       rollingWith === 'Advantage'
         ? result.details.extraDie.advantageRoll
-        : result.details.extraDie.disadvantageRoll
-    embed.addFields({ name: 'Roll Type', value: rollingWith, inline: true })
-    embed.addFields({
-      name: `${rollingWith} Die (d6)`,
-      value: String(dieRoll),
-      inline: true
-    })
+        : -result.details.extraDie.disadvantageRoll
+    facts.push({ label: `${rollingWith} (d6)`, value: formatSignedModifier(extra) })
   }
 
-  return embed
+  if (modifier !== 0) facts.push({ label: 'Modifier', value: formatSignedModifier(modifier) })
+  facts.push({ label: 'Total', value: String(result.total) })
+
+  return [
+    rollContainer({
+      accent,
+      headline,
+      consequence,
+      facts,
+      body: [
+        `**Hope ${hopeSides}**  ${result.details.hope.roll}   **Fear ${fearSides}**  ${result.details.fear.roll}`
+      ],
+      derivation: `${hopeSides} ${result.details.hope.roll} / ${fearSides} ${result.details.fear.roll} ${formatSignedModifier(modifier)} = ${result.total}`,
+      rerollId: `r:dh:${modifier}:${difficulty ?? ''}:${rollingWith ?? ''}:${amplifyHope ? 1 : 0}:${amplifyFear ? 1 : 0}`
+    })
+  ]
 }
 
 export const dhCommand: Command = createGameCommand({
@@ -104,11 +130,19 @@ export const dhCommand: Command = createGameCommand({
         .setDescription('Amplify Fear die (use d20 instead of d12)')
         .setRequired(false)
     )
+    .addIntegerOption(option =>
+      option
+        .setName('difficulty')
+        .setDescription('Difficulty to beat — resolves the roll into success or failure')
+        .setRequired(false)
+        .setMinValue(1)
+        .setMaxValue(50)
+    )
     .addBooleanOption(option =>
       option
         .setName('hidden')
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildDhEmbed
+  buildView: buildDhView
 })

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -1,65 +1,144 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/fate'
 import type { FateRollResult } from '@randsum/games/fate'
-import { embedFooterDetails } from '../utils/constants.js'
-import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { FATE, GLYPH } from '../utils/palette.js'
+import {
+  createGameCommand,
+  formatSignedModifier,
+  getInitialRolls,
+  rollContainer
+} from './lib/index.js'
+import type { CommandContext, ViewFact } from './lib/index.js'
+import type { Command, RollView } from '../types.js'
 
 const SKILL_MIN = -2
 const SKILL_MAX = 5
 
 // Keyed by the exported FateRollResult union so the ladder map stays
-// exhaustive: renaming the result strings surfaces here as a type error
-// rather than a silent miss. `label` is the human-readable ladder rung shown
-// to the player; the result strings themselves are snake_case.
+// exhaustive: renaming the result strings surfaces here as a type error rather
+// than a silent miss. `label` is the human-readable ladder rung shown to the
+// player; the result strings themselves are snake_case.
 const ladder: Record<FateRollResult, { readonly color: number; readonly label: string }> = {
-  legendary: { color: 0xffd700, label: 'Legendary' },
-  epic: { color: 0xffd700, label: 'Epic' },
-  fantastic: { color: 0x2ecc71, label: 'Fantastic' },
-  superb: { color: 0x2ecc71, label: 'Superb' },
-  great: { color: 0x2ecc71, label: 'Great' },
-  good: { color: 0x3498db, label: 'Good' },
-  fair: { color: 0x3498db, label: 'Fair' },
-  average: { color: 0x95a5a6, label: 'Average' },
-  mediocre: { color: 0x95a5a6, label: 'Mediocre' },
-  poor: { color: 0xe67e22, label: 'Poor' },
-  terrible: { color: 0xe74c3c, label: 'Terrible' }
+  legendary: { color: FATE.legendary, label: 'Legendary' },
+  epic: { color: FATE.legendary, label: 'Epic' },
+  fantastic: { color: FATE.great, label: 'Fantastic' },
+  superb: { color: FATE.great, label: 'Superb' },
+  great: { color: FATE.great, label: 'Great' },
+  good: { color: FATE.good, label: 'Good' },
+  fair: { color: FATE.good, label: 'Fair' },
+  average: { color: FATE.average, label: 'Average' },
+  mediocre: { color: FATE.average, label: 'Mediocre' },
+  poor: { color: FATE.poor, label: 'Poor' },
+  terrible: { color: FATE.terrible, label: 'Terrible' }
 }
 
-function fateDieSymbol(die: number): string {
-  if (die > 0) return '+'
-  if (die < 0) return '−'
-  return '▢'
+/**
+ * Fate dice as monospace tiles.
+ *
+ * The printed form in the book is `[+] [-] [ ]`, and inline code gives fixed
+ * width so a 4dF spread reads as a row rather than drifting. It also replaces
+ * `▢` (U+25A2), which has patchy font coverage and rendered as tofu on some
+ * Android and Linux configurations.
+ *
+ * Fate is the one game where boxing beats bold/strikethrough: Discord ignores
+ * markdown inside a code span, so tiles and kept/dropped marking are mutually
+ * exclusive — and Fate has no drop mechanic to mark.
+ */
+function fateDieTile(die: number): string {
+  if (die > 0) return '`[+]`'
+  if (die < 0) return '`[-]`'
+  return '`[ ]`'
 }
 
-function buildFateEmbed(context: CommandContext): EmbedBuilder {
+/**
+ * Fate's real outcomes are measured in shifts against opposition, not by the
+ * ladder rung of the total in isolation. Four bands, per Fate Core.
+ */
+function shiftOutcome(shifts: number): {
+  glyph: string
+  name: string
+  note: string
+  accent: number
+} {
+  if (shifts >= 3) {
+    return {
+      glyph: GLYPH.critical,
+      name: 'Succeed with Style',
+      note: 'Take a boost, or succeed at greater effect.',
+      accent: FATE.legendary
+    }
+  }
+  if (shifts > 0) {
+    return { glyph: GLYPH.success, name: 'Success', note: 'You do it.', accent: FATE.great }
+  }
+  if (shifts === 0) {
+    return {
+      glyph: GLYPH.mixed,
+      name: 'Tie',
+      note: 'You succeed at a minor cost, or get a lesser result.',
+      accent: FATE.average
+    }
+  }
+  return {
+    glyph: GLYPH.failure,
+    name: 'Fail',
+    note: 'Fail, or succeed at serious cost.',
+    accent: FATE.terrible
+  }
+}
+
+function buildFateView(context: CommandContext): RollView {
   const rawSkill = context.options.getInteger('skill') ?? 0
   const skill = Math.max(SKILL_MIN, Math.min(SKILL_MAX, rawSkill))
+  const opposition = context.options.getInteger('opposition')
 
   const result = roll({ modifier: skill })
   const dice = getInitialRolls(result)
-  const symbols = dice.map(fateDieSymbol).join('  ')
+  const rung = ladder[result.result]
 
-  const embed = new EmbedBuilder()
-    .setColor(ladder[result.result].color)
-    .setTitle(ladder[result.result].label)
-    .setDescription(`Total: ${result.total}`)
-    .setFooter(embedFooterDetails)
+  const facts: ViewFact[] = []
+  if (skill !== 0) facts.push({ label: 'Skill', value: formatSignedModifier(skill) })
+  facts.push({ label: 'Total', value: formatSignedModifier(result.total) })
 
-  embed.addFields({ name: 'Fate Dice (4dF)', value: symbols || 'None', inline: true })
+  const headline = `${rung.label} (${formatSignedModifier(result.total)})`
 
-  if (skill !== 0) {
-    embed.addFields({
-      name: 'Skill',
-      value: formatSignedModifier(skill),
-      inline: true
-    })
+  if (opposition !== null) {
+    const shifts = result.total - opposition
+    const outcome = shiftOutcome(shifts)
+    const magnitude = Math.abs(shifts)
+    const shiftText =
+      shifts === 0
+        ? 'A tie'
+        : `${magnitude} shift${magnitude === 1 ? '' : 's'} ${shifts > 0 ? 'over' : 'under'}`
+
+    return [
+      rollContainer({
+        // The OUTCOME drives the accent here, not the ladder rung. They are two
+        // different axes: a Legendary (+9) against opposition of +10 is a Fail,
+        // and painting that gold told the player the opposite of the word beside
+        // it. The rung still leads the headline, because it is what the dice
+        // said; the colour reports what it got you.
+        accent: outcome.accent,
+        headline: `${outcome.glyph} ${headline}  ·  ${outcome.name}`,
+        consequence: `${shiftText} opposition of ${formatSignedModifier(opposition)}. ${outcome.note}`,
+        facts,
+        body: [dice.map(fateDieTile).join(' ')],
+        derivation: `4dF ${formatSignedModifier(skill)} = ${formatSignedModifier(result.total)} vs ${formatSignedModifier(opposition)}`,
+        rerollId: `r:fate:${skill}:${opposition}`
+      })
+    ]
   }
 
-  embed.addFields({ name: 'Total', value: String(result.total), inline: true })
-
-  return embed
+  return [
+    rollContainer({
+      accent: rung.color,
+      headline,
+      facts,
+      body: [dice.map(fateDieTile).join(' ')],
+      derivation: `4dF ${formatSignedModifier(skill)} = ${formatSignedModifier(result.total)}`,
+      rerollId: `r:fate:${skill}:`
+    })
+  ]
 }
 
 export const fateCommand: Command = createGameCommand({
@@ -69,10 +148,18 @@ export const fateCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('skill')
-        .setDescription('Skill rating on the Fate ladder (-2 to +5)')
+        .setDescription('Skill rating (-2 to 5)')
         .setRequired(false)
         .setMinValue(SKILL_MIN)
         .setMaxValue(SKILL_MAX)
+    )
+    .addIntegerOption(option =>
+      option
+        .setName('opposition')
+        .setDescription('Opposition to beat — resolves shifts into a Fate outcome')
+        .setRequired(false)
+        .setMinValue(-4)
+        .setMaxValue(10)
     )
     .addBooleanOption(option =>
       option
@@ -80,5 +167,5 @@ export const fateCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildFateEmbed
+  buildView: buildFateView
 })

--- a/apps/discord-bot/src/commands/fifth.ts
+++ b/apps/discord-bot/src/commands/fifth.ts
@@ -1,18 +1,20 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/fifth'
-import { embedFooterDetails } from '../utils/constants.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { FIFTH, GLYPH } from '../utils/palette.js'
 import {
   createGameCommand,
   formatSignedModifier,
   getInitialRolls,
   getKeptRolls,
-  markKeptRolls
+  markKeptRolls,
+  rollContainer
 } from './lib/index.js'
-import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import type { CommandContext, ViewFact } from './lib/index.js'
+import type { Command, RollView } from '../types.js'
 
-function buildFifthEmbed(context: CommandContext): EmbedBuilder {
+function buildFifthView(context: CommandContext): RollView {
   const modifier = context.options.getInteger('modifier') ?? 0
+  const dc = context.options.getInteger('dc')
   const rollingWith = context.options.getString('rolling_with') as
     | 'Advantage'
     | 'Disadvantage'
@@ -30,37 +32,71 @@ function buildFifthEmbed(context: CommandContext): EmbedBuilder {
   const isNat20 = criticals?.isNatural20 === true
   const isNat1 = criticals?.isNatural1 === true
 
-  const embedColor = isNat20 ? 0xffd700 : isNat1 ? 0xdc143c : 0x1e90ff
-  const titlePrefix = isNat20 ? 'Natural 20! ' : isNat1 ? 'Natural 1! ' : ''
+  // 5e is the one game where the raw total genuinely is the headline — bounded
+  // accuracy means the whole resolution is "compare this number to a DC or AC".
+  // So the number leads, and the system name (which the player just typed) does
+  // not appear at all.
+  // A natural and a DC verdict are independent axes, and a d20 can roll a 1 on
+  // a +30 modifier that still clears a DC 10. Rendering the fumble glyph and
+  // the fumble accent over the word "Success" said the opposite of the line
+  // below it — the same two-axis mistake as labelling a kept-lowest die
+  // "Highest Roll". When a DC is supplied it decides both; the natural is still
+  // announced in words, because it changes what the roll means at the table.
+  const passed = dc !== null ? result.total >= dc : null
+  const accent =
+    passed === true
+      ? FIFTH.natural20
+      : passed === false
+        ? FIFTH.natural1
+        : isNat20
+          ? FIFTH.natural20
+          : isNat1
+            ? FIFTH.natural1
+            : FIFTH.standard
 
-  const embed = new EmbedBuilder()
-    .setColor(embedColor)
-    .setTitle(`${titlePrefix}D&D 5e Roll: ${result.total}`)
-    .setDescription(rollingWith ? `Rolled with ${rollingWith}` : 'Standard roll')
-    .setFooter(embedFooterDetails)
+  const naturalGlyph = isNat20 ? GLYPH.critical : isNat1 ? GLYPH.fumble : null
+  const verdictGlyph = passed === true ? GLYPH.success : passed === false ? GLYPH.failure : null
+  const glyph = verdictGlyph ?? naturalGlyph
 
-  const rollsText =
-    rollingWith && initialRolls.length > 1
-      ? markKeptRolls(initialRolls, keptRolls)
-      : initialRolls.join(', ')
+  const marker = isNat20 ? 'Natural 20' : isNat1 ? 'Natural 1' : null
 
-  embed.addFields({
-    name: rollingWith ? 'Dice Rolled (2d20)' : 'Die Rolled (1d20)',
-    value: rollsText || 'None',
-    inline: true
-  })
+  // The glyph binds to the marker it qualifies — `✸ Natural 20` — and the
+  // separator only ever divides that prefix from the total.
+  const prefix = [glyph, marker].filter(part => part !== null).join(' ')
+  const headline = prefix.length > 0 ? `${prefix}  ·  ${result.total}` : String(result.total)
 
-  if (modifier !== 0) {
-    embed.addFields({
-      name: 'Modifier',
-      value: formatSignedModifier(modifier),
-      inline: true
+  // A natural 20 is an automatic hit on ATTACK ROLLS under the 2014 rules — not
+  // on ability checks or saving throws. The 2024 rules changed that. This
+  // wording is true under both, where a bare "automatic success" would not be.
+  const critLine = isNat20
+    ? 'Critical hit on an attack roll.'
+    : isNat1
+      ? 'Critical miss on an attack roll.'
+      : null
+
+  const dcLine = dc !== null ? `${result.total >= dc ? 'Success' : 'Failure'} vs DC ${dc}` : null
+
+  const consequence = [dcLine, critLine].filter(line => line !== null).join(' — ')
+
+  const facts: ViewFact[] = []
+  if (modifier !== 0) facts.push({ label: 'Modifier', value: formatSignedModifier(modifier) })
+  facts.push({ label: 'Total', value: String(result.total) })
+
+  const dropped = initialRolls.length > keptRolls.length
+  const dice = dropped ? markKeptRolls(initialRolls, keptRolls) : initialRolls.join(', ')
+  const label = rollingWith !== null ? `2d20, ${rollingWith}` : '1d20'
+
+  return [
+    rollContainer({
+      accent,
+      headline,
+      ...(consequence.length > 0 ? { consequence } : {}),
+      facts,
+      body: [`**${label}**  ${dice}`],
+      derivation: `${label} ${formatSignedModifier(modifier)} = ${result.total}`,
+      rerollId: `r:fifth:${modifier}:${dc ?? ''}:${rollingWith ?? ''}`
     })
-  }
-
-  embed.addFields({ name: 'Total', value: String(result.total), inline: true })
-
-  return embed
+  ]
 }
 
 export const fifthCommand: Command = createGameCommand({
@@ -85,11 +121,19 @@ export const fifthCommand: Command = createGameCommand({
           { name: 'Disadvantage', value: 'Disadvantage' }
         )
     )
+    .addIntegerOption(option =>
+      option
+        .setName('dc')
+        .setDescription('Difficulty Class to beat — shows success or failure')
+        .setRequired(false)
+        .setMinValue(1)
+        .setMaxValue(50)
+    )
     .addBooleanOption(option =>
       option
         .setName('hidden')
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildFifthEmbed
+  buildView: buildFifthView
 })

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -2,10 +2,9 @@ import type { EmbedBuilder } from '../../utils/builders.js'
 import type { Command, RollView } from '../../types.js'
 import type { CommandContext } from './context.js'
 
-export type { CommandContext, CommandOptions } from './context.js'
-export { optionsFromPayload } from './context.js'
-export type { RollContainerOptions, ViewFact } from './view.js'
-export { CUSTOM_ID_LIMIT, renderFacts, renderTrace, rollContainer } from './view.js'
+export type { CommandContext } from './context.js'
+export type { ViewFact } from './view.js'
+export { renderTrace, rollContainer } from './view.js'
 
 /**
  * Exactly one renderer, never neither.

--- a/apps/discord-bot/src/commands/pbta.ts
+++ b/apps/discord-bot/src/commands/pbta.ts
@@ -1,17 +1,43 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/pbta'
-import { embedFooterDetails } from '../utils/constants.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { GLYPH, PBTA } from '../utils/palette.js'
 import {
   createGameCommand,
   formatSignedModifier,
   getInitialRolls,
   getKeptRolls,
-  markKeptRolls
+  markKeptRolls,
+  rollContainer
 } from './lib/index.js'
-import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import type { CommandContext, ViewFact } from './lib/index.js'
+import type { Command, RollView } from '../types.js'
 
-function buildPbtaEmbed(context: CommandContext): EmbedBuilder {
+/**
+ * The band leads, its name follows.
+ *
+ * PbtA is a family, not a game: Apocalypse World says "10+", Dungeon World says
+ * "strong hit", Masks says something else again. The numeric band is the part
+ * that travels to every table running any of them.
+ */
+const OUTCOMES = {
+  strong_hit: {
+    accent: PBTA.strongHit,
+    headline: `${GLYPH.success} 10+  ·  Strong Hit`,
+    consequence: "You do it. Take the move's full effect."
+  },
+  weak_hit: {
+    accent: PBTA.weakHit,
+    headline: `${GLYPH.mixed} 7-9  ·  Weak Hit`,
+    consequence: 'You do it, but the MC picks a complication or a cost.'
+  },
+  miss: {
+    accent: PBTA.miss,
+    headline: `${GLYPH.failure} 6-  ·  Miss`,
+    consequence: 'The MC makes a move. In most PbtA games, mark experience.'
+  }
+} as const
+
+function buildPbtaView(context: CommandContext): RollView {
   const stat = context.options.getInteger('stat', true)
   const forward = context.options.getInteger('forward') ?? 0
   const ongoing = context.options.getInteger('ongoing') ?? 0
@@ -28,52 +54,38 @@ function buildPbtaEmbed(context: CommandContext): EmbedBuilder {
   })
 
   const initialRolls = getInitialRolls(result)
-
-  const resultConfig = {
-    strong_hit: { color: 0xffd700, resultTitle: 'Strong Hit!' },
-    weak_hit: { color: 0xffff00, resultTitle: 'Weak Hit' },
-    miss: { color: 0xff0000, resultTitle: 'Miss' }
-  } as const
-
-  const { color, resultTitle } = resultConfig[result.result]
-
-  const embed = new EmbedBuilder()
-    .setColor(color)
-    .setTitle(resultTitle)
-    .setDescription(`Total: ${result.total}`)
-    .setFooter(embedFooterDetails)
-
   const keptRolls = getKeptRolls(result)
-  const diceText =
-    initialRolls.length > keptRolls.length
-      ? markKeptRolls(initialRolls, keptRolls)
-      : initialRolls.join(', ')
+  const outcome = OUTCOMES[result.result]
 
-  embed.addFields({ name: 'Dice Rolled', value: diceText || 'None', inline: true })
-  embed.addFields({ name: 'Stat', value: stat >= 0 ? `+${stat}` : String(stat), inline: true })
-  embed.addFields({ name: 'Total', value: String(result.total), inline: true })
+  const facts: ViewFact[] = [{ label: 'Stat', value: formatSignedModifier(stat) }]
+  if (forward !== 0) facts.push({ label: 'Forward', value: formatSignedModifier(forward) })
+  if (ongoing !== 0) facts.push({ label: 'Ongoing', value: formatSignedModifier(ongoing) })
+  // `details.diceTotal` is the dice-only subtotal the engine computes and the
+  // embed renderer never showed — exactly the number a PbtA player wants beside
+  // their modifiers.
+  facts.push({ label: 'Dice', value: String(result.details.diceTotal) })
+  facts.push({ label: 'Total', value: String(result.total) })
 
-  if (forward !== 0) {
-    embed.addFields({
-      name: 'Forward',
-      value: formatSignedModifier(forward),
-      inline: true
+  const dropped = initialRolls.length > keptRolls.length
+  const dice = dropped ? markKeptRolls(initialRolls, keptRolls) : initialRolls.join(', ')
+
+  return [
+    rollContainer({
+      accent: outcome.accent,
+      headline: outcome.headline,
+      consequence: outcome.consequence,
+      facts,
+      body: [
+        // Naming the mechanic in the label is what makes the strikethrough
+        // self-explaining rather than something to decode.
+        dropped
+          ? `**3d6, keep ${rollingWith === 'Disadvantage' ? 'worst' : 'best'} 2**  ${dice}`
+          : `**2d6**  ${dice}`
+      ],
+      derivation: `${result.details.diceTotal} ${formatSignedModifier(result.total - result.details.diceTotal)} = ${result.total}`,
+      rerollId: `r:pbta:${stat}:${forward}:${ongoing}:${rollingWith ?? ''}`
     })
-  }
-
-  if (ongoing !== 0) {
-    embed.addFields({
-      name: 'Ongoing',
-      value: formatSignedModifier(ongoing),
-      inline: true
-    })
-  }
-
-  if (rollingWith) {
-    embed.addFields({ name: 'Rolling With', value: rollingWith, inline: true })
-  }
-
-  return embed
+  ]
 }
 
 export const pbtaCommand: Command = createGameCommand({
@@ -83,7 +95,7 @@ export const pbtaCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('stat')
-        .setDescription('Your stat modifier (-3 to 5)')
+        .setDescription('The stat modifier for this move (-3 to 5)')
         .setRequired(true)
         .setMinValue(-3)
         .setMaxValue(5)
@@ -91,7 +103,7 @@ export const pbtaCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('forward')
-        .setDescription('One-time forward bonus (-5 to 5)')
+        .setDescription('Bonus taken forward (-5 to 5)')
         .setRequired(false)
         .setMinValue(-5)
         .setMaxValue(5)
@@ -99,7 +111,7 @@ export const pbtaCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('ongoing')
-        .setDescription('Persistent ongoing bonus (-5 to 5)')
+        .setDescription('Ongoing bonus (-5 to 5)')
         .setRequired(false)
         .setMinValue(-5)
         .setMaxValue(5)
@@ -107,11 +119,11 @@ export const pbtaCommand: Command = createGameCommand({
     .addStringOption(option =>
       option
         .setName('rolling_with')
-        .setDescription('Roll with advantage or disadvantage')
+        .setDescription('Roll 3d6 and keep the best or worst two')
         .setRequired(false)
         .addChoices(
-          { name: 'Advantage', value: 'Advantage' },
-          { name: 'Disadvantage', value: 'Disadvantage' }
+          { name: 'Best 2 of 3', value: 'Advantage' },
+          { name: 'Worst 2 of 3', value: 'Disadvantage' }
         )
     )
     .addBooleanOption(option =>
@@ -120,5 +132,5 @@ export const pbtaCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildPbtaEmbed
+  buildView: buildPbtaView
 })

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -2,12 +2,10 @@ import { roll } from '@randsum/roller/roll'
 import type { TraceableRollRecord } from '@randsum/roller/trace'
 import { notation as createNotation } from '@randsum/roller/validate'
 import { SlashCommandBuilder } from '../utils/builders.js'
+import { BRAND } from '../utils/palette.js'
 import { createGameCommand, renderTrace, rollContainer } from './lib/index.js'
 import type { CommandContext } from './lib/index.js'
 import type { Command, RollView } from '../types.js'
-
-/** Brand purple. `/roll` has no outcome tier, so the accent is identity. */
-const ROLL_ACCENT = 0x7c3aed
 
 /**
  * Containers rendered before the rest are summarised away.
@@ -106,7 +104,7 @@ function buildRollView(context: CommandContext): RollView {
     const description = (record.description ?? []).join(' · ')
 
     return rollContainer({
-      accent: ROLL_ACCENT,
+      accent: BRAND,
       // A single pool leads with the number, because that is the answer. Several
       // pools lead with which pool this is, and the grand total gets its own
       // line below.
@@ -122,7 +120,7 @@ function buildRollView(context: CommandContext): RollView {
     const omitted = result.rolls.length - pools.length
     containers.push(
       rollContainer({
-        accent: ROLL_ACCENT,
+        accent: BRAND,
         headline: `Total  ${result.total}`,
         ...(omitted > 0
           ? { consequence: `${omitted} further pool${omitted === 1 ? '' : 's'} not shown.` }

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -1,51 +1,79 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/root-rpg'
-import { embedFooterDetails } from '../utils/constants.js'
-import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { CommandContext } from './lib/index.js'
-import type { Command } from '../types.js'
+import { SlashCommandBuilder } from '../utils/builders.js'
+import { GLYPH, ROOT } from '../utils/palette.js'
+import {
+  createGameCommand,
+  formatSignedModifier,
+  getInitialRolls,
+  getKeptRolls,
+  markKeptRolls,
+  rollContainer
+} from './lib/index.js'
+import type { CommandContext, ViewFact } from './lib/index.js'
+import type { Command, RollView } from '../types.js'
 
-function buildRootEmbed(context: CommandContext): EmbedBuilder {
-  const modifier = context.options.getInteger('modifier') ?? 0
-  const displayName = context.userDisplayName
-
-  const result = roll({ bonus: modifier })
-  const initialRolls = getInitialRolls(result)
-
-  const resultConfig = {
-    strong_hit: {
-      label: 'Strong Hit',
-      color: 0x00ff00,
-      resultDescription: 'You succeed at your goal'
-    },
-    weak_hit: {
-      label: 'Weak Hit',
-      color: 0xffff00,
-      resultDescription: 'You succeed, but with a cost or complication'
-    },
-    miss: { label: 'Miss', color: 0xff0000, resultDescription: "Things don't go your way" }
-  } as const
-
-  const { color, resultDescription, label } = resultConfig[result.result]
-
-  const embed = new EmbedBuilder()
-    .setColor(color)
-    .setTitle(`${displayName} rolled a ${label}`)
-    .setDescription(resultDescription)
-    .setFooter(embedFooterDetails)
-
-  embed.addFields({ name: 'Dice Rolls', value: initialRolls.join(', '), inline: true })
-  embed.addFields({ name: 'Total', value: String(result.total), inline: true })
-
-  if (modifier !== 0) {
-    embed.addFields({
-      name: 'Modifier',
-      value: formatSignedModifier(modifier),
-      inline: true
-    })
+const OUTCOMES = {
+  strong_hit: {
+    accent: ROOT.strongHit,
+    headline: `${GLYPH.success} 10+  ·  Strong Hit`,
+    consequence: 'You pull it off cleanly.'
+  },
+  weak_hit: {
+    accent: ROOT.weakHit,
+    headline: `${GLYPH.mixed} 7-9  ·  Weak Hit`,
+    consequence: 'You do it, but it costs you something.'
+  },
+  miss: {
+    accent: ROOT.miss,
+    headline: `${GLYPH.failure} 6-  ·  Miss`,
+    consequence: 'The GM says how the Woodland pushes back.'
   }
+} as const
 
-  return embed
+/**
+ * Root's stats have names, and a player reads their sheet by name rather than
+ * by integer. Naming the stat is what lets the roll read back as the thing they
+ * actually said out loud: "Cunning, strong hit".
+ */
+const STATS = ['Charm', 'Cunning', 'Finesse', 'Luck', 'Might'] as const
+
+function buildRootView(context: CommandContext): RollView {
+  const bonus = context.options.getInteger('modifier') ?? 0
+  const stat = context.options.getString('stat')
+  const rollingWith = context.options.getString('rolling_with') as
+    | 'Advantage'
+    | 'Disadvantage'
+    | null
+
+  const result = roll({ bonus, ...(rollingWith ? { rollingWith } : {}) })
+
+  const initialRolls = getInitialRolls(result)
+  const keptRolls = getKeptRolls(result)
+  const outcome = OUTCOMES[result.result]
+
+  const facts: ViewFact[] = []
+  if (stat !== null) facts.push({ label: stat, value: formatSignedModifier(bonus) })
+  else if (bonus !== 0) facts.push({ label: 'Modifier', value: formatSignedModifier(bonus) })
+  facts.push({ label: 'Total', value: String(result.total) })
+
+  const dropped = initialRolls.length > keptRolls.length
+  const dice = dropped ? markKeptRolls(initialRolls, keptRolls) : initialRolls.join(', ')
+
+  // The invoking user is NOT named here. Discord already renders
+  // "<username> used /root" directly above every response, so the old
+  // "Alex rolled a Weak Hit" title repeated it — and made this the one command
+  // whose title shape differed from its nine siblings.
+  return [
+    rollContainer({
+      accent: outcome.accent,
+      headline: stat !== null ? `${outcome.headline}  ·  ${stat}` : outcome.headline,
+      consequence: outcome.consequence,
+      facts,
+      body: [dropped ? `**3d6, keep 2**  ${dice}` : `**2d6**  ${dice}`],
+      derivation: `2d6 ${formatSignedModifier(bonus)} = ${result.total}`,
+      rerollId: `r:root:${bonus}:${stat ?? ''}:${rollingWith ?? ''}`
+    })
+  ]
 }
 
 export const rootCommand: Command = createGameCommand({
@@ -55,10 +83,27 @@ export const rootCommand: Command = createGameCommand({
     .addIntegerOption(option =>
       option
         .setName('modifier')
-        .setDescription('Modifier to add to the roll')
+        .setDescription('Stat bonus for this move (-3 to 5)')
         .setRequired(false)
         .setMinValue(-3)
         .setMaxValue(5)
+    )
+    .addStringOption(option =>
+      option
+        .setName('stat')
+        .setDescription('Which stat this move uses')
+        .setRequired(false)
+        .addChoices(...STATS.map(name => ({ name, value: name })))
+    )
+    .addStringOption(option =>
+      option
+        .setName('rolling_with')
+        .setDescription('Roll 3d6 and keep the best or worst two')
+        .setRequired(false)
+        .addChoices(
+          { name: 'Best 2 of 3', value: 'Advantage' },
+          { name: 'Worst 2 of 3', value: 'Disadvantage' }
+        )
     )
     .addBooleanOption(option =>
       option
@@ -66,5 +111,5 @@ export const rootCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: buildRootEmbed
+  buildView: buildRootView
 })

--- a/apps/discord-bot/src/utils/builders.ts
+++ b/apps/discord-bot/src/utils/builders.ts
@@ -36,8 +36,7 @@ export {
   SeparatorBuilder,
   SlashCommandBuilder,
   StringSelectMenuBuilder,
-  TextDisplayBuilder,
-  ThumbnailBuilder
+  TextDisplayBuilder
 } from '@discordjs/builders'
 
 export {

--- a/apps/discord-bot/src/utils/palette.ts
+++ b/apps/discord-bot/src/utils/palette.ts
@@ -1,0 +1,104 @@
+/**
+ * The accent palette and outcome glyphs — the bot's whole visual vocabulary.
+ *
+ * Before this file the colours were fourteen inline literals across eight
+ * command files, drawn from three unrelated sources: saturated RGB primaries
+ * (`0x00ff00`), the Flat-UI set (`0x2ecc71`), and CSS named colours
+ * (`dodgerblue`). Two consequences worth remembering, because both were live
+ * bugs in the output rather than untidiness:
+ *
+ * - Green meant two different greens. Root's strong hit was `0x00ff00` and
+ *   Fate's Great was `0x2ecc71` — the same semantic tier, visibly different.
+ * - Failure was indistinguishable from a crash. A missed `/root` roll and a
+ *   validation error both rendered `0xff0000`.
+ *
+ * And gold meant nothing in particular: it was the critical accent for five
+ * commands, the chrome for `/help` and `/notation`, and the unconditional
+ * colour of `/roll`, so the bot's most common output was permanently dressed as
+ * a critical success.
+ *
+ * Two layers now. **Outcome tier** picks the accent within a game, so a
+ * player reads success-versus-failure before reading any text. **System
+ * identity** picks which green, so a Blades success and a Root success are both
+ * green without being the same green.
+ *
+ * Every value clears Discord's dark-theme ground (`#313338`). That rules out
+ * some tonally correct choices — Blades' soot-and-gaslight palette is
+ * represented by its accents rather than its near-black ground, which would
+ * simply disappear.
+ */
+
+/**
+ * Outcome glyphs, which carry the same signal as the accent without relying on
+ * colour.
+ *
+ * Roughly 8% of men have a red/green deficiency, which is a real slice of any
+ * TTRPG server, and Discord's accent bar is 4px of hue with no label. These are
+ * shape-differentiated so they survive greyscale, and they are plain text — no
+ * custom emoji to host, no per-platform rendering differences.
+ */
+export const GLYPH = {
+  /** Best possible: a Blades critical, a natural 20, a Daggerheart crit. */
+  critical: '✸',
+  /** Unqualified success. */
+  success: '◆',
+  /** Success with a cost, a partial, a weak hit — the middle band. */
+  mixed: '◈',
+  /** Failure or a miss. */
+  failure: '✕',
+  /** The worst case, reserved for a natural 1. */
+  fumble: '☠'
+} as const
+
+/** Blades in the Dark — grimy industrial-occult: brass, ghost-fire, dried blood. */
+export const BLADES = {
+  critical: 0xe8c547,
+  success: 0x4fb3a5,
+  partial: 0xc9762f,
+  failure: 0x8b1e1e
+} as const
+
+/** Daggerheart — gold Hope against deep-violet Fear, the game's own language. */
+export const DAGGERHEART = {
+  critical: 0xffce45,
+  /** Deliberately dimmer than `critical`, so a crit reads as *more*. */
+  hope: 0xd99a2b,
+  fear: 0x5b2c8d
+} as const
+
+/** PbtA — no fictional palette to borrow, so a clean semantic ramp. */
+export const PBTA = {
+  strongHit: 0x2f9e6b,
+  weakHit: 0xd9822b,
+  miss: 0xc0392b
+} as const
+
+/** Root — Ferrin's storybook woodland: green, Marquise orange, deep berry. */
+export const ROOT = {
+  strongHit: 0x4a7c3f,
+  weakHit: 0xc97b2b,
+  miss: 0x6b2737
+} as const
+
+/** D&D 5e — PHB red and brass, rather than the generic web blue it had. */
+export const FIFTH = {
+  natural20: 0xe8b44a,
+  standard: 0xb01b2e,
+  natural1: 0x7a1418
+} as const
+
+/**
+ * Fate — the existing six-step ramp, which was already the right instinct.
+ * Only the hexes are retuned; the shape of the ramp is unchanged.
+ */
+export const FATE = {
+  legendary: 0xf2c14e,
+  great: 0x3fa46a,
+  good: 0x3e8fc1,
+  average: 0x8e9aa3,
+  poor: 0xd2812f,
+  terrible: 0xb03a3a
+} as const
+
+/** `/roll` and the informational commands. Brand identity, not an outcome. */
+export const BRAND = 0x7c3aed

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -93,7 +93,7 @@ function resolveDisplayName(payload: InteractionPayload): string {
  * rows and a container is rejected. It composes with `Ephemeral` as a normal
  * bit flag — 32768 | 64 — so the `hidden` option keeps working unchanged.
  */
-export function viewResponse(view: RollView, hidden: boolean): unknown {
+function viewResponse(view: RollView, hidden: boolean): unknown {
   return {
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {


### PR DESCRIPTION
## Summary

Every roll command now renders through the shared container, leads with its outcome in the game's own words, and carries an accent that means something. Also adds the three optional comparison inputs.

**Stacked on #1242.** Review order: #1239 → #1240 → #1241 → #1242 → this.

## A palette replaces fourteen inline literals

`utils/palette.ts` is the single source. Two of the old collisions were live bugs, not untidiness:

- **Green meant two different greens** — Root's strong hit `0x00ff00` against Fate's Great `0x2ecc71`. Same semantic tier, visibly different swatch.
- **Failure was byte-identical to a crash** — a missed `/root` roll and a validation error both rendered `0xff0000`.

Outcome tier now picks the accent *within* a game; system identity picks *which* green.

**Outcome glyphs carry the same signal without colour**: ✸ critical, ◆ success, ◈ mixed, ✕ failure, ☠ fumble. Roughly 8% of men have a red/green deficiency and Discord's accent bar is 4px of unlabelled hue, so shape is what survives. Plain text — nothing to host, no per-platform rendering differences.

## Per command

Real output from this branch:

```
## ◆ Success with Fear  ·  16 vs DC 14
The GM gains a Fear.
**Modifier** +2  ·  **Total** 16
**Hope d12**  4   **Fear d12**  11
-# d12 4 / d12 11 +2 = 16 · rolled with 👹 by randsum.dev
```

**`/dh` — the largest content gap closed.** Daggerheart resolves on a *grid*: success-or-failure AND hope-or-fear. Without a difficulty the bot could only render the second, so **"Success with Fear" — the result that most defines the game — looked identical to a plain failure.** `difficulty` is optional; the headline falls back to the duality axis without it. "Critical Hope!" was never a Daggerheart term (the game says Critical Success, Rolled with Hope, Rolled with Fear), and the consequence — you gain a Hope, the GM gains a Fear, a crit clears a Stress — was stated nowhere. Amplified dice are now labelled from `details.*.amplified` rather than re-derived from the option flags, and a disadvantage die is shown **signed**, because the engine subtracts it.

**`/blades`** — the book's register: "You do it", "You do it, but there's a consequence", "Things go badly". Field is "Deciding Die", correct at rating 0 and above alike. A test now pins that the *kept* die is bolded at rating 0, which is the #1239 bug in its final form.

**`/pbta`** — the band leads, the name follows (`10+ · Strong Hit`), because PbtA is a family and the numeric band travels to every table running one. "Advantage" was D&D vocabulary imported into a line that deliberately avoids it — the choices now read **Best 2 of 3** / **Worst 2 of 3**. `details.diceTotal`, computed on every roll and never rendered, sits beside the modifiers.

**`/root`** — same band-first treatment, plus an optional **named stat**, so a roll reads back the way a player says it out loud ("Cunning, strong hit"). The invoking user is no longer named — Discord already renders "*username* used /root" directly above the response, which is why this was the one command whose title shape differed from its nine siblings. `rolling_with` is now exposed; the spec always supported it.

**`/fifth`** — the total leads (bounded accuracy makes the number the result) and the system name the player just typed is gone from the headline. New optional `dc` resolves the roll. Natural-20 copy reads "Critical hit on an **attack roll**", which is true under both the 2014 and 2024 rules where a bare "automatic success" is not.

**`/fate`** — dice render as monospace tiles `` `[+]` `[-]` `[ ]` ``, the printed form, replacing `▢` (U+25A2) which tofus on some Android and Linux fonts. New optional `opposition` resolves shifts into Fate's real outcomes — Fail, Tie, Success, Succeed with Style — where a bare ladder rung told a Fate player nothing.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

Adds three optional slash-command options (`dc`, `opposition`, `difficulty`) and one on `/root` (`stat`, `rolling_with`). **This needs `bun run deploy-commands`** — per `apps/discord-bot/CLAUDE.md`, registration is manual and skipping it has already caused one outage.

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

- **The PbtA "Advantage"→"Best 2 of 3" rename changes a choice label users see.** The stored `value` is unchanged, so nothing breaks, but it's a visible wording change worth a second opinion.
- **`/root`'s new `stat` option is display-only** — it doesn't alter the roll, just names the modifier. Deliberate, but say so if you'd rather it were wired to per-stat values.
- **Knip caught real dead weight.** The pre-push hook failed on unused exports I'd added (`BRAND` duplicated by a local constant in `/roll`, `ERROR` unused until the error container lands, plus several barrel re-exports used only by tests, which knip doesn't scan). All removed rather than ignored.
- I have **not** verified the mobile clients — still the open item from #1242.

## Checklist

- [x] `bun run check:all` passes for the touched package; `knip` clean
- [x] Tests cover the change — 130 pass, up from 125; each command's outcome copy, accent, and new option are covered, plus regression guards for the Blades kept-die and the PbtA option key
- [x] Bundle size limits respected (no new dependencies)
- [x] No public API change outside the private bot
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_