### PR TITLE
feat(discord-bot): migrate /notation, /help and /salvageunion to Components V2

### DIFF
--- a/apps/discord-bot/__tests__/commands/help.test.ts
+++ b/apps/discord-bot/__tests__/commands/help.test.ts
@@ -1,51 +1,40 @@
 import { describe, expect, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
+import { helpCommand } from '../../src/commands/help.js'
+import { commands } from '../../src/commands/index.js'
 import { makeContext } from './lib/context.js'
+import { accentsOf, textOf } from '../lib/view.js'
+import { BRAND } from '../../src/utils/palette.js'
 
-const { helpCommand } = await import('../../src/commands/help.js')
-
-function render(): APIEmbed {
-  return helpCommand.buildEmbed!(makeContext()).toJSON()
-}
+const view = helpCommand.buildView!(makeContext([]))
+const text = textOf(view)
 
 describe('helpCommand', () => {
-  test('has name "help"', () => {
-    expect(helpCommand.data.name).toBe('help')
+  test('lists commands from the barrel, excluding help itself', () => {
+    for (const command of commands) {
+      if (command.data.name === 'help') continue
+      expect(text).toContain(`/${command.data.name}`)
+    }
+    expect(text).not.toContain('**/help')
   })
 
-  test('has a description', () => {
-    expect(typeof helpCommand.data.description).toBe('string')
-    expect(helpCommand.data.description.length).toBeGreaterThan(0)
+  test('names each required option, so the list is usable without guessing', () => {
+    // The embed version could tell you `/pbta` existed but not that it needs a
+    // stat — nine full-width fields of names and descriptions, no usage.
+    expect(text).toContain('**/pbta <stat>**')
+    expect(text).toContain('**/roll <notation>**')
   })
 
-  test('exposes a hidden option', () => {
-    const json = helpCommand.data.toJSON() as { options?: { name: string }[] }
-    const optionNames = (json.options ?? []).map(o => o.name)
-    expect(optionNames).toContain('hidden')
+  test('a command with no required options is listed without a hint', () => {
+    expect(text).toContain('**/fate**')
   })
 
-  test('embed uses gold color', () => {
-    expect(render().color).toBe(0xffd700)
+  test('points at the two ways in: /roll and /notation', () => {
+    expect(text).toContain('`/roll`')
+    expect(text).toContain('`/notation`')
   })
 
-  test('embed includes footer', () => {
-    expect(render().footer).toBeDefined()
-  })
-
-  test('lists commands from the barrel, excluding help itself', async () => {
-    // Source of truth changed deliberately. `/help` used to read
-    // `client.commands`, which only existed on the gateway — the Worker has no
-    // client, so the same command could not have rendered there. It reads the
-    // command barrel, which `apps/discord-bot/CLAUDE.md` already calls the
-    // single source of truth for what commands exist.
-    //
-    // Importing the barrel is what publishes the registry, so the import below
-    // is load-bearing rather than incidental.
-    await import('../../src/commands/index.js')
-
-    const fieldNames = (render().fields ?? []).map(field => field.name)
-    expect(fieldNames).toContain('/roll')
-    expect(fieldNames).toContain('/blades')
-    expect(fieldNames).not.toContain('/help')
+  test('carries the brand accent and the attribution', () => {
+    expect(accentsOf(view)[0]).toBe(BRAND)
+    expect(text).toContain('rolled with 👹 by randsum.dev')
   })
 })

--- a/apps/discord-bot/__tests__/commands/notation.test.ts
+++ b/apps/discord-bot/__tests__/commands/notation.test.ts
@@ -1,91 +1,71 @@
-import { describe, expect, mock, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
+import { describe, expect, test } from 'bun:test'
+import { notationCommand } from '../../src/commands/notation.js'
+import { NOTATION_SELECT_ID, buildNotationView } from '../../src/commands/lib/notationView.js'
 import { makeContext } from './lib/context.js'
+import { textOf } from '../lib/view.js'
+import type { RollView } from '../../src/types.js'
 
-// Mock NOTATION_DOCS with a controlled fixture so tests are deterministic
-const mockNotationDocs = {
-  L: {
-    key: 'L',
-    category: 'Filter',
-    title: 'Drop Lowest',
-    description: 'Drops the lowest die from the pool',
-    color: '#abc123',
-    colorLight: '#123abc',
-    displayBase: 'L',
-    forms: [{ notation: 'NdSL', note: 'Drop lowest die' }],
-    examples: [{ notation: '4d6L', description: 'Roll 4d6, drop lowest' }]
-  },
-  H: {
-    key: 'H',
-    category: 'Filter',
-    title: 'Drop Highest',
-    description: 'Drops the highest die from the pool',
-    color: '#abc123',
-    colorLight: '#123abc',
-    displayBase: 'H',
-    forms: [{ notation: 'NdSH', note: 'Drop highest die' }],
-    examples: [{ notation: '4d6H', description: 'Roll 4d6, drop highest' }]
-  },
-  'C{..}': {
-    key: 'C{..}',
-    category: 'Clamp',
-    title: 'Cap',
-    description: 'Clamps dice to a range',
-    color: '#def456',
-    colorLight: '#456def',
-    displayBase: 'C{..}',
-    forms: [{ notation: 'NdSC{..}', note: 'Cap dice' }],
-    examples: [{ notation: '4d6C{>5}', description: 'Cap at 5' }]
-  }
-}
-
-void mock.module('@randsum/roller/docs', () => ({
-  NOTATION_DOCS: mockNotationDocs
-}))
-
-const { notationCommand } = await import('../../src/commands/notation.js')
-
-/** The select menu as it reaches Discord — `buildComponents` returns raw API JSON. */
-interface ApiActionRow {
-  readonly components: readonly {
-    readonly custom_id?: string
-    readonly options?: readonly { readonly label: string }[]
-  }[]
-}
-
-function renderEmbed(): APIEmbed {
-  return notationCommand.buildEmbed!(makeContext()).toJSON()
-}
-
-function renderComponents(): readonly ApiActionRow[] {
-  return notationCommand.buildComponents!(makeContext()) as readonly ApiActionRow[]
+function selectOptions(view: RollView): { label: string; default: boolean | undefined }[] {
+  return view.flatMap(container =>
+    container.toJSON().components.flatMap(component => {
+      if (component.type !== 1) return []
+      return component.components.flatMap(control =>
+        control.type === 3 && control.custom_id === NOTATION_SELECT_ID
+          ? control.options.map(option => ({ label: option.label, default: option.default }))
+          : []
+      )
+    })
+  )
 }
 
 describe('notationCommand', () => {
-  test('embed title links to notation.randsum.dev', () => {
-    const embed = renderEmbed()
-    expect(embed.title).toBe('notation.randsum.dev')
-    expect(embed.url).toBe('https://notation.randsum.dev')
+  const view = notationCommand.buildView!(makeContext([]))
+
+  test('renders one container, with the selector inside it', () => {
+    // Under embeds this was an embed plus a detached action row beneath. The
+    // select menu nests inside a container, so the reference is one card.
+    expect(view).toHaveLength(1)
+    expect(selectOptions(view).length).toBeGreaterThan(1)
   })
 
-  test('embed shows fields for first category entries', () => {
-    expect((renderEmbed().fields ?? []).length).toBeGreaterThan(0)
+  test('the current category is marked selected in the menu', () => {
+    const chosen = selectOptions(view).filter(option => option.default === true)
+    expect(chosen).toHaveLength(1)
   })
 
-  test('components include a select menu with category options', () => {
-    const labels = (renderComponents()[0]?.components[0]?.options ?? []).map(o => o.label)
-    expect(labels).toContain('Filter')
-    expect(labels).toContain('Clamp')
+  test('links out to the notation site', () => {
+    expect(textOf(view)).toContain('https://notation.randsum.dev')
   })
 
-  test('components are plain JSON, not builders', () => {
-    // The dispatcher spreads these straight into the interaction response body,
-    // so the raw API fields must already be there. A builder keeps its fields
-    // under `.data` and would serialize to something Discord rejects, leaving a
-    // reference page with no way to change category.
-    const [row] = renderComponents()
-    expect(row).toBeDefined()
-    expect(row?.components[0]?.custom_id).toBe('notation-category')
-    expect(row).not.toHaveProperty('data')
+  test('a page says where it is in the sequence', () => {
+    // Twelve categories with no counter and a placeholder reading "Select a
+    // category" gave no sense of how much reference there was.
+    expect(textOf(view)).toMatch(/Page \d+ of \d+/)
+  })
+
+  test("each category uses the notation site's own colour, not one flat gold", () => {
+    // `NotationDoc.color` is a per-category identity the site already uses and
+    // the embed renderer discarded, painting all twelve pages the same.
+    const filter = buildNotationView('Filter')[0]?.toJSON().accent_color
+    const scale = buildNotationView('Scale')[0]?.toJSON().accent_color
+    expect(filter).toBeDefined()
+    expect(filter).not.toBe(scale)
+  })
+
+  test('the page describes its own entries rather than calling them all modifiers', () => {
+    // Every page used to read "**<category>** modifiers", including Core and
+    // Special, which are dice *types*.
+    expect(textOf(buildNotationView('Core'))).not.toContain('modifiers')
+  })
+
+  test('an unrecognised category falls back rather than rendering empty', () => {
+    // A stale menu on an old message must not produce a blank reference page.
+    expect(textOf(buildNotationView('NotACategory')).length).toBeGreaterThan(0)
+  })
+
+  test('renders the entries for the requested category', () => {
+    const text = textOf(buildNotationView('Filter'))
+    expect(text).toContain('## Filter')
+    expect(text).toContain('Drop Lowest')
   })
 })

--- a/apps/discord-bot/__tests__/commands/salvageunion.test.ts
+++ b/apps/discord-bot/__tests__/commands/salvageunion.test.ts
@@ -1,32 +1,49 @@
 import { describe, expect, test } from 'bun:test'
-import type { APIEmbed } from 'discord.js'
+import { salvageUnionCommand } from '../../src/commands/salvageunion.js'
 import { makeContext } from './lib/context.js'
+import { textOf } from '../lib/view.js'
 
-const { salvageUnionCommand } = await import('../../src/commands/salvageunion.js')
+const view = salvageUnionCommand.buildView!(makeContext([]))
 
-function render(): APIEmbed {
-  return salvageUnionCommand.buildEmbed!(makeContext()).toJSON()
+/** Link buttons carry a `url` and no `custom_id`, so they need no round trip. */
+function linkButtons(): { label: string | undefined; url: string | undefined }[] {
+  return view.flatMap(container =>
+    container.toJSON().components.flatMap(component =>
+      component.type === 1
+        ? component.components.map(button => ({
+            label: 'label' in button ? button.label : undefined,
+            url: 'url' in button ? button.url : undefined
+          }))
+        : []
+    )
+  )
 }
 
 describe('salvageUnionCommand', () => {
-  test('is registered as /salvageunion, not /su', () => {
-    expect(salvageUnionCommand.data.name).toBe('salvageunion')
-  })
-
-  test('takes no table option — it no longer rolls', () => {
-    const options = salvageUnionCommand.data.toJSON().options ?? []
-    expect(options.map(option => option.name)).toEqual(['hidden'])
-  })
-
   test('points at the SURef bot instead of rolling', () => {
-    const embed = render()
-    expect(embed.title).toBe('Salvage Union has moved')
-    expect(embed.description).toContain('SURef')
+    const text = textOf(view)
+    expect(text).toContain('Salvage Union has moved')
+    expect(text).toContain('SURef')
   })
 
-  test('includes the SURef invite and info links', () => {
-    const fieldValues = (render().fields ?? []).map(field => field.value).join('\n')
-    expect(fieldValues).toContain('client_id=1442878052823470172')
-    expect(fieldValues).toContain('https://salvageunion.io/discord')
+  test('the call to action is a pair of link buttons, not links in a field', () => {
+    // This is the one command whose whole purpose is a call to action, and it
+    // spent it on markdown links buried in embed fields. A button is a tap
+    // target, which is what matters on the phone where most invites happen.
+    const buttons = linkButtons()
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0]?.url).toContain('discord.com/oauth2/authorize')
+    expect(buttons[1]?.url).toBe('https://salvageunion.io/discord')
+  })
+
+  test('link buttons carry no custom_id, so they need no dispatcher branch', () => {
+    for (const container of view) {
+      for (const component of container.toJSON().components) {
+        if (component.type !== 1) continue
+        for (const button of component.components) {
+          expect('custom_id' in button).toBe(false)
+        }
+      }
+    }
   })
 })

--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -106,24 +106,26 @@ describe('dispatchInteraction', () => {
     expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
 
     // The real proof it reads the registry: a Worker has no client, so an
-    // empty field list here would mean /help silently renders nothing.
-    const names = (response.data?.embeds?.[0]?.fields ?? []).map(field => field.name)
-    expect(names).toContain('/roll')
-    expect(names).not.toContain('/help')
+    // empty list here would mean /help silently renders nothing.
+    const text = JSON.stringify(response.data?.components)
+    expect(text).toContain('/roll')
+    expect(text).not.toContain('**/help')
   })
 
   test('renders /salvageunion', () => {
     const response = invoke('salvageunion')
     expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
-    expect(response.data?.embeds?.[0]?.title).toBe('Salvage Union has moved')
+    expect(JSON.stringify(response.data?.components)).toContain('Salvage Union has moved')
   })
 
   test('renders /notation with its category selector attached', () => {
     const response = invoke('notation')
-    expect(response.data?.embeds?.[0]?.title).toBe('notation.randsum.dev')
-    // The embed alone would be a reference page with no way to change category
-    // — working, but silently missing the entire interaction.
-    expect(response.data?.components).toBeDefined()
+    // The selector now lives inside the container rather than in a detached row,
+    // so a missing menu would be a reference page with no way to change
+    // category — working, but silently missing the entire interaction.
+    const payload = JSON.stringify(response.data?.components)
+    expect(payload).toContain('notation.randsum.dev')
+    expect(payload).toContain('notation-category')
   })
 
   test('every command has a Worker renderer', () => {
@@ -147,7 +149,11 @@ describe('dispatchInteraction', () => {
     // Type 7 edits the existing message rather than posting a new one, matching
     // the gateway path's `.update()`.
     expect(response.type).toBe(7)
-    expect(response.data?.embeds?.[0]?.title).toBe('notation.randsum.dev')
+    // The V2 flag has to be set on the edit too: it cannot be removed once a
+    // message carries it, and omitting it makes Discord read the container as a
+    // malformed action row.
+    expect(response.data?.flags).toBe(32768)
+    expect(JSON.stringify(response.data?.components)).toContain('notation.randsum.dev')
   })
 
   test('an unrecognised category falls back rather than rendering empty', () => {
@@ -158,7 +164,7 @@ describe('dispatchInteraction', () => {
     ) as Rendered
 
     expect(response.type).toBe(7)
-    expect(response.data?.embeds?.[0]?.fields?.length).toBeGreaterThan(0)
+    expect(JSON.stringify(response.data?.components).length).toBeGreaterThan(100)
   })
 
   test('returns undefined for interaction types it does not handle', () => {

--- a/apps/discord-bot/src/commands/help.ts
+++ b/apps/discord-bot/src/commands/help.ts
@@ -1,15 +1,36 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
-import { embedFooterDetails } from '../utils/constants.js'
+import {
+  ContainerBuilder,
+  SeparatorBuilder,
+  SeparatorSpacingSize,
+  SlashCommandBuilder,
+  TextDisplayBuilder
+} from '../utils/builders.js'
+import { FOOTER_ATTRIBUTION } from '../utils/constants.js'
 import { createGameCommand } from './lib/index.js'
 import { commandRegistry } from './lib/registry.js'
+import { BRAND } from '../utils/palette.js'
 import type { Command } from '../types.js'
 
 /**
  * `/help` reads the registry rather than `client.commands`, which is what makes
- * it work on both transports — a Worker has no client to read a registry off.
+ * it work without a gateway — a Worker has no client to read a registry off.
  * The barrel publishes the list; see `lib/registry.ts` for why it is pushed
  * rather than imported.
+ *
+ * The embed version stacked nine full-width fields, one per command, which is a
+ * tall wall of text with no usage information: it could tell you `/pbta` exists
+ * but not that it requires a `stat`. Each line now carries the command's
+ * required options, which is the part a reader actually needs.
  */
+function requiredOptionHint(command: Command): string {
+  const options = command.data.options
+    .map(option => option.toJSON())
+    .filter(option => option.required === true)
+    .map(option => `<${option.name}>`)
+
+  return options.length > 0 ? ` ${options.join(' ')}` : ''
+}
+
 export const helpCommand: Command = createGameCommand({
   data: new SlashCommandBuilder()
     .setName('help')
@@ -20,20 +41,35 @@ export const helpCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildEmbed: () => {
-    const fields = commandRegistry()
+  buildView: () => {
+    const lines = commandRegistry()
       .filter(command => command.data.name !== 'help')
-      .map(command => ({
-        name: `/${command.data.name}`,
-        value: command.data.description,
-        inline: false
-      }))
+      .map(
+        command =>
+          `**/${command.data.name}${requiredOptionHint(command)}**\n-# ${command.data.description}`
+      )
 
-    return new EmbedBuilder()
-      .setColor(0xffd700)
-      .setTitle('RANDSUM Commands')
-      .setDescription('Here are all the available commands:')
-      .addFields(fields)
-      .setFooter(embedFooterDetails)
+    return [
+      new ContainerBuilder()
+        .setAccentColor(BRAND)
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent('## RANDSUM Commands'),
+          new TextDisplayBuilder().setContent(
+            'Roll dice for a specific system, or use `/roll` with any RANDSUM notation. `/notation` is the full reference.'
+          )
+        )
+        .addSeparatorComponents(
+          new SeparatorBuilder().setDivider(true).setSpacing(SeparatorSpacingSize.Small)
+        )
+        // A TextDisplay rejects empty content, and the registry is populated by
+        // the barrel at import time — so an empty list is a real (if unlikely)
+        // crash rather than a blank section.
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            lines.length > 0 ? lines.join('\n') : '-# No commands are registered.'
+          )
+        )
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${FOOTER_ATTRIBUTION}`))
+    ]
   }
 })

--- a/apps/discord-bot/src/commands/lib/notationView.ts
+++ b/apps/discord-bot/src/commands/lib/notationView.ts
@@ -1,5 +1,6 @@
 /**
- * The `/notation` reference view — embed plus category selector.
+ * The `/notation` reference view — one container holding the reference text
+ * and its own category selector.
  *
  * Extracted when there were two transports, so both rendered the identical
  * thing. Only the Worker remains: it builds this view and returns it, then
@@ -14,12 +15,21 @@
  * `data.values[0]`. The selection *is* the state, and it arrives with the
  * interaction. The existing static custom_id was never the problem.
  */
-import { ActionRowBuilder, EmbedBuilder, StringSelectMenuBuilder } from '../../utils/builders.js'
+import {
+  ActionRowBuilder,
+  ContainerBuilder,
+  SeparatorBuilder,
+  SeparatorSpacingSize,
+  StringSelectMenuBuilder,
+  TextDisplayBuilder
+} from '../../utils/builders.js'
 import { NOTATION_DOCS } from '@randsum/roller/docs'
 import type { NotationDoc } from '@randsum/roller/docs'
-import { embedFooterDetails } from '../../utils/constants.js'
+import { FOOTER_ATTRIBUTION } from '../../utils/constants.js'
+import { BRAND } from '../../utils/palette.js'
+import type { RollView } from '../../types.js'
 
-/** Shared by both transports so a rename cannot desynchronise them. */
+/** Shared by the view and the dispatcher so a rename cannot desynchronise them. */
 export const NOTATION_SELECT_ID = 'notation-category'
 
 export function groupByCategory(
@@ -37,29 +47,70 @@ export function groupByCategory(
   return groups
 }
 
-export function buildCategoryEmbed(
-  category: string,
-  entries: readonly NotationDoc[]
-): EmbedBuilder {
-  const fields = entries.map(doc => ({
-    name: `${doc.title} (${doc.displayBase})`,
-    value: [
-      doc.description,
-      ...doc.examples.map(example => `**\`${example.notation}\`** — ${example.description}`)
-    ].join('\n'),
-    inline: false
-  }))
-
-  return new EmbedBuilder()
-    .setColor(0xffd700)
-    .setTitle('notation.randsum.dev')
-    .setURL('https://notation.randsum.dev')
-    .setDescription(`**${category}** modifiers`)
-    .addFields(fields)
-    .setFooter(embedFooterDetails)
+/**
+ * `NotationDoc.color` is a CSS hex string; Discord wants an integer.
+ * Falls back to the brand accent when a doc has no colour or an unusable one.
+ */
+function parseHex(color: string | undefined): number {
+  if (color === undefined) return BRAND
+  const parsed = Number.parseInt(color.replace('#', ''), 16)
+  return Number.isNaN(parsed) ? BRAND : parsed
 }
 
-export function buildCategoryMenu(
+/**
+ * One category page.
+ *
+ * `doc.color` is a per-category identity the notation site already uses and the
+ * bot discarded, painting every page the same gold. It is the accent now, so
+ * Filter and Scale are visually distinct pages rather than the same page with
+ * different words.
+ *
+ * The old description read "**<category>** modifiers" for every page, including
+ * Core and Special — which are dice *types*, not modifiers.
+ */
+function buildCategoryContainer(
+  category: string,
+  entries: readonly NotationDoc[],
+  categories: readonly string[]
+): ContainerBuilder {
+  const container = new ContainerBuilder()
+    .setAccentColor(parseHex(entries[0]?.color))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `## ${category}\n[notation.randsum.dev](https://notation.randsum.dev)`
+      )
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setDivider(true).setSpacing(SeparatorSpacingSize.Small)
+    )
+
+  for (const doc of entries) {
+    const lines = [
+      `**${doc.title}** \`${doc.displayBase}\``,
+      doc.description,
+      // `comparisons` — the operator cheat-sheet, and the hardest part of the
+      // notation to remember — was fetched and dropped by the embed renderer.
+      ...(doc.comparisons ?? []).map(
+        comparison => `-# \`${comparison.operator}\` — ${comparison.note}`
+      ),
+      ...doc.examples.map(example => `\`${example.notation}\` — ${example.description}`)
+    ]
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(lines.join('\n')))
+  }
+
+  container.addActionRowComponents(buildCategoryMenu(categories, category))
+
+  const position = categories.indexOf(category) + 1
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(
+      `-# Page ${position} of ${categories.length} · ${FOOTER_ATTRIBUTION}`
+    )
+  )
+
+  return container
+}
+
+function buildCategoryMenu(
   categories: readonly string[],
   selected: string
 ): ActionRowBuilder<StringSelectMenuBuilder> {
@@ -77,24 +128,16 @@ export function buildCategoryMenu(
   return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)
 }
 
-export interface NotationView {
-  readonly embed: EmbedBuilder
-  readonly row: ActionRowBuilder<StringSelectMenuBuilder>
-}
-
 /**
  * Build the whole view for one category. Falls back to the first category when
  * given nothing or an unrecognised value — a stale menu from an old message
  * must not render an empty reference page.
  */
-export function buildNotationView(category?: string | undefined): NotationView {
+export function buildNotationView(category?: string | undefined): RollView {
   const grouped = groupByCategory()
   const categories = [...grouped.keys()]
   const fallback = categories[0] ?? 'Core'
   const selected = category !== undefined && grouped.has(category) ? category : fallback
 
-  return {
-    embed: buildCategoryEmbed(selected, grouped.get(selected) ?? []),
-    row: buildCategoryMenu(categories, selected)
-  }
+  return [buildCategoryContainer(selected, grouped.get(selected) ?? [], categories)]
 }

--- a/apps/discord-bot/src/commands/notation.ts
+++ b/apps/discord-bot/src/commands/notation.ts
@@ -23,6 +23,8 @@ export const notationCommand: Command = {
   // Worker holds nothing open, so the menu simply stays live — Discord re-POSTs
   // every selection, and a click on a very old message renders the same page it
   // always did rather than a disabled control.
-  buildEmbed: () => buildNotationView().embed,
-  buildComponents: () => [buildNotationView().row.toJSON()]
+  // Under Components V2 the select menu lives inside the container, so what
+  // used to be a separate `buildComponents` returning a detached action row is
+  // now part of the one view — and the view is built once rather than twice.
+  buildView: () => buildNotationView()
 }

--- a/apps/discord-bot/src/commands/salvageunion.ts
+++ b/apps/discord-bot/src/commands/salvageunion.ts
@@ -1,5 +1,12 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
-import { embedFooterDetails } from '../utils/constants.js'
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ContainerBuilder,
+  SlashCommandBuilder,
+  TextDisplayBuilder
+} from '../utils/builders.js'
+import { FOOTER_ATTRIBUTION } from '../utils/constants.js'
 import { createGameCommand } from './lib/index.js'
 import type { Command } from '../types.js'
 
@@ -9,12 +16,18 @@ import type { Command } from '../types.js'
  * This command replaces the old `/su` roller: it no longer rolls, it points.
  * The rename also frees `/su` in servers running both bots — SURef owns that
  * name now.
+ *
+ * Rust orange is kept from the embed version: it was already the right colour
+ * for a post-apocalyptic mech-salvage game, and it is the one accent in the bot
+ * that never needed retuning.
  */
 
 /** SURef's application id — public by design, it appears in every invite URL. */
 const SUREF_CLIENT_ID = '1442878052823470172'
 const SUREF_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${SUREF_CLIENT_ID}&scope=bot%20applications.commands&permissions=0`
 const SUREF_INFO_URL = 'https://salvageunion.io/discord'
+
+const RUST = 0xb7410e
 
 export const salvageUnionCommand: Command = createGameCommand({
   data: new SlashCommandBuilder()
@@ -26,18 +39,34 @@ export const salvageUnionCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  // Static content, so it takes no context at all — which is exactly why it
-  // moves to the factory for free and works on either transport unchanged.
-  buildEmbed: () =>
-    new EmbedBuilder()
-      .setColor(0xb7410e)
-      .setTitle('Salvage Union has moved')
-      .setDescription(
-        'RANDSUM no longer rolls Salvage Union tables. **SURef**, the official bot from salvageunion.io, does it better — every table, plus lookups for any chassis, system, module, or piece of equipment, linked back to the full SRD entry.'
+  // Static content, so it takes no context at all.
+  //
+  // This is the one command whose whole purpose is a call to action, and it
+  // spent it on two markdown links buried in embed fields. Link buttons need no
+  // custom_id and no interaction round trip — they work on a stateless Worker
+  // unchanged — and they are a tap target rather than a text link, which is
+  // what matters on the phone where most "add this bot" taps happen.
+  buildView: () => [
+    new ContainerBuilder()
+      .setAccentColor(RUST)
+      .addTextDisplayComponents(
+        new TextDisplayBuilder().setContent('## Salvage Union has moved'),
+        new TextDisplayBuilder().setContent(
+          'RANDSUM no longer rolls Salvage Union tables. **SURef**, the official bot from salvageunion.io, does it better — every table, plus lookups for any chassis, system, module, or piece of equipment, linked back to the full SRD entry.'
+        )
       )
-      .addFields(
-        { name: 'Add SURef to your server', value: `[Invite the bot](${SUREF_INVITE_URL})` },
-        { name: 'Learn more', value: `[salvageunion.io/discord](${SUREF_INFO_URL})` }
+      .addActionRowComponents(
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setLabel('Add SURef to your server')
+            .setStyle(ButtonStyle.Link)
+            .setURL(SUREF_INVITE_URL),
+          new ButtonBuilder()
+            .setLabel('Learn more')
+            .setStyle(ButtonStyle.Link)
+            .setURL(SUREF_INFO_URL)
+        )
       )
-      .setFooter(embedFooterDetails)
+      .addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${FOOTER_ATTRIBUTION}`))
+  ]
 })

--- a/apps/discord-bot/src/utils/constants.ts
+++ b/apps/discord-bot/src/utils/constants.ts
@@ -1,12 +1,12 @@
-export const embedFooterDetails = {
-  text: 'Rolled with 👹 by randsum.dev'
-}
-
 /**
  * The attribution half of the footer line.
  *
  * Components V2 has no footer primitive — the line is composed by hand as `-#`
- * subtext — and every roll now prefixes it with that roll's derivation, so the
+ * subtext — and every roll prefixes it with that roll's derivation, so the
  * constant is the attribution alone rather than the whole string.
+ *
+ * This replaced `embedFooterDetails`, which was the identical string applied by
+ * hand in nine command files and omitted from the tenth surface entirely (the
+ * error response). It went when the last embed renderer did.
  */
 export const FOOTER_ATTRIBUTION = 'rolled with 👹 by randsum.dev'

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -135,9 +135,12 @@ function dispatchComponent(payload: InteractionPayload): unknown {
   return {
     type: InteractionResponseType.UpdateMessage,
     data: {
+      // The V2 flag is required on an edit exactly as on the original message:
+      // it cannot be removed once set, and omitting it here would make Discord
+      // read the container as a malformed action row.
+      flags: MessageFlags.IsComponentsV2,
       allowed_mentions: NO_MENTIONS,
-      embeds: [view.embed.toJSON()],
-      components: [view.row.toJSON()]
+      components: view.map(container => container.toJSON())
     }
   }
 }


### PR DESCRIPTION
## Summary

The last three renderers. **Every command in the barrel is now on `buildView`** — which sets up the next PR to delete the embed path entirely.

**Stacked on #1243.** Review order: #1239 → #1240 → #1241 → #1242 → #1243 → this.

## `/notation` collapses into one container

The select menu nests *inside* the container rather than sitting in a detached action row beneath, so the reference is a single card. `buildNotationView` is also called once per render instead of twice — the split `buildEmbed`/`buildComponents` pair forced two full passes over `NOTATION_DOCS`.

Three things the embed renderer fetched and threw away now reach the reader:

- **`doc.color`** — a per-category identity the notation site already uses. The bot painted all twelve pages the same gold. Filter and Scale are now visually distinct pages rather than the same page with different words.
- **`doc.comparisons`** — the operator cheat-sheet (`>n`, `>=n`, `<n`, …), and the hardest part of the notation to remember.
- **A page counter.** Twelve categories behind a placeholder reading "Select a category" gave no sense of how much reference there was.

The description also stops calling every page "modifiers", which was wrong for Core and Special — those are dice *types*.

## `/help` gains usage

Nine full-width fields could tell you `/pbta` existed but not that it requires a `stat`:

```
**/pbta <stat>**
-# Roll dice for Powered by the Apocalypse games
**/roll <notation>**
-# Test your luck with a roll of the dice
```

## `/salvageunion` gets real link buttons

This is the one command whose entire purpose is a call to action, and it spent it on two markdown links buried in embed fields. Link buttons carry a URL and **no `custom_id`**, so they need no dispatcher branch and no round trip — they work on a stateless Worker unchanged, and they're a tap target rather than a text link, which is what matters on the phone where most "add this bot" taps happen. A test pins that they carry no `custom_id`, so nobody later adds one and wonders why clicking 400s.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

- **The component-update path now sets `IsComponentsV2` on the edit too.** The flag cannot be removed once a message carries it, and omitting it on the type-7 response would make Discord read the container as a malformed action row. Pinned by a test.
- **`embedFooterDetails` is deleted here**, because this PR removed its last consumer and `knip` fails the pre-push hook on a dead export. It was the same string applied by hand in nine files — and omitted from the tenth surface, the error response, which is why that was the only message in the bot without a footer. The error response is still on the old shape; it becomes a container in the next PR.
- **`/help` guards an empty registry.** A `TextDisplay` rejects empty content, so `lines.join('\n')` on an empty list threw rather than rendering a blank section. Unlikely (the barrel populates it at import time) but a real crash, and I hit it while checking the output.

## Still outstanding across the stack

- **The Reroll buttons added in #1242/#1243 are not wired up yet.** `dispatchComponent` only recognises the notation select, so a click currently returns HTTP 400 with no user-visible message. That's handled in the last PR of the stack; flagging it because it's a genuine intermediate state if these merge one at a time rather than together.
- Mobile client verification is still undone.

## Checklist

- [x] `bun run check:all` passes for the touched package; `knip` clean
- [x] Tests cover the change — 132 pass, up from 130; new coverage for the nested selector, per-category colours, the page counter, `/help` usage hints, and the link buttons
- [x] Bundle size limits respected (no new dependencies)
- [x] No public API change outside the private bot
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_