### PR TITLE
refactor(discord-bot): delete the embed path

### DIFF
--- a/apps/discord-bot/CLAUDE.md
+++ b/apps/discord-bot/CLAUDE.md
@@ -25,7 +25,7 @@ artifact to produce ahead of a deploy. It is listed in `BUILD_EXEMPT` in
 apps/discord-bot/
   src/
     deploy-commands.ts   # One-shot Node script: writes the slash command registry
-    types.ts             # Command interface (data, buildEmbed, buildComponents)
+    types.ts             # Command interface (data, buildView)
     worker/
       index.ts           # Worker entry: verifies the signature, dispatches, responds
       verify.ts          # Ed25519 request-signature verification (WebCrypto)
@@ -45,9 +45,10 @@ apps/discord-bot/
       lib/               # Shared command scaffolding (context, notation view, factory)
     utils/
       builders.ts        # PORTABLE Discord primitives — safe on workerd. Commands import here.
+      palette.ts         # Accent colours and outcome glyphs — the visual vocabulary
       discord.ts         # discord.js REST barrel — deploy-commands only, never the Worker
       config.ts          # Reads env vars; throws on missing required vars (deploy-commands only)
-      constants.ts       # Embed footer
+      constants.ts       # Footer attribution
 ```
 
 The `builders.ts` / `discord.ts` split is load-bearing and outlived the gateway. Command files
@@ -150,18 +151,28 @@ global registrations were untouched by the Cloudflare cutover and by dropping Re
 Each command file exports a named `*Command` object with:
 
 - `data` — a `SlashCommandBuilder` defining the name, description, and options
-- `buildEmbed(context)` — the renderer the Worker calls. Takes a `CommandContext` (option
-  accessors plus the caller's display name) and returns an `EmbedBuilder`. Pure: no interaction,
-  no network, no replying.
-- `buildComponents(context)` — optional, raw API JSON. Only `/notation` has one.
+- `buildView(context)` — the renderer the Worker calls. Takes a `CommandContext` (option
+  accessors plus the caller's display name) and returns a `RollView`: `readonly
+  ContainerBuilder[]`, one **Components V2** container per dice pool. Pure: no interaction, no
+  network, no replying.
 
-> The `execute(interaction)` handler that used to sit here is **gone**, along with `autocomplete`
-> (which was declared, accepted by the factory, and never once passed). Errors are the
-> dispatcher's job now: `buildEmbed` throws, and `dispatchInteraction` renders the error embed.
+> `buildEmbed` and `buildComponents` are **gone**, as `execute(interaction)` and `autocomplete`
+> went before them. The bot renders Components V2 exclusively: setting `IsComponentsV2` forbids
+> `embeds` outright, so the two shapes cannot be mixed on one message. Errors are the
+> dispatcher's job: `buildView` throws, and `dispatchInteraction` renders the error container.
 >
-> `buildEmbed` is optional on the interface so the dispatcher can answer "not available on this
+> `buildView` is optional on the interface so the dispatcher can answer "not available on this
 > deployment" rather than guess, but every command in the barrel has one and
 > `__tests__/worker/dispatch.test.ts` holds that line.
+
+**Building a view.** Route through `rollContainer()` in `commands/lib/view.ts` rather than
+assembling a container by hand — it owns the headline / consequence / facts / body / derivation
+layout, and the `-#` subtext footer that replaces the embed footer Components V2 does not have.
+`renderTrace()` turns a `RollRecord` into the step lines (`@randsum/roller/trace`), and
+`utils/palette.ts` holds every accent colour and outcome glyph. Two constraints worth knowing:
+Components V2 has no `inline` field grid, so label/value pairs go through `renderFacts` as one
+line; and a `custom_id` caps at 100 characters, so a reroll button carrying long notation is
+dropped rather than truncated (Discord rejects the whole message otherwise).
 
 All game commands import their `roll()` from the corresponding `@randsum/games/<shortcode>`
 subpath. The exception is `/salvageunion`, which rolls nothing: Salvage Union moved to the SURef
@@ -178,8 +189,19 @@ also frees that name for SURef in servers running both bots.
 
 ## Testing
 
-Tests use real discord.js builders (not mocks) and verify output via `toJSON()` on embeds. Only
-game packages (`@randsum/games/*`) and roller subpaths (`@randsum/roller/*`) are mocked.
+Tests use real discord.js builders (not mocks). Only game packages (`@randsum/games/*`) and
+roller subpaths (`@randsum/roller/*`) are mocked.
+
+Assert against a view through the helpers in `__tests__/lib/view.ts` — `textOf`, `linesOf`,
+`accentsOf`, `buttonIdsOf` — rather than walking the component tree. A container has no title,
+so the literal equivalent of `expect(embed.data.title)` is
+`view[0]!.toJSON().components[0]!.content`, which breaks when a separator moves rather than when
+the text changes.
+
+**Two traps.** `bun test` does not typecheck, so a test can pass while violating
+`exactOptionalPropertyTypes` — run `bun run check`. And `mock.module` leaks across test files
+**even under `--isolate`**, so a test relying on an un-mocked import can pass alone and fail in
+the suite; supply explicit fixtures instead.
 
 `worker/dispatch.ts` is pure — no network, no client, no side effects — which is what makes the
 bot's actual behaviour testable without a Worker runtime. It is the half worth protecting; the

--- a/apps/discord-bot/__tests__/commands/index.test.ts
+++ b/apps/discord-bot/__tests__/commands/index.test.ts
@@ -38,16 +38,15 @@ describe('commands barrel', () => {
   })
 
   test('each command has data and a renderer', () => {
-    // A renderer replaced `execute` as the thing every command must have. Both
-    // are optional on the interface so the dispatcher can answer "not available
-    // on this deployment" rather than guess — but a command that ships without
-    // either is unreachable in production, so the barrel is where that is
-    // checked. `buildView` is the Components V2 renderer commands are migrating
-    // to; `buildEmbed` is accepted until the last one moves.
+    // `buildView` replaced `buildEmbed`, which replaced `execute`, as the thing
+    // every command must have. It is optional on the interface so the
+    // dispatcher can answer "not available on this deployment" rather than
+    // guess — but a command that ships without one is unreachable in
+    // production, so the barrel is where that is checked.
     for (const command of commands) {
       expect(command).toHaveProperty('data')
       expect(command.data).toBeDefined()
-      expect(typeof (command.buildView ?? command.buildEmbed)).toBe('function')
+      expect(typeof command.buildView).toBe('function')
     }
   })
 

--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -2,7 +2,7 @@
  * Covers the HTTP-interactions dispatcher against the REAL command barrel.
  *
  * Using the real commands rather than fixtures is the point: this is the test
- * that would catch a command whose `buildEmbed` quietly depends on something a
+ * that would catch a command whose renderer quietly depends on something a
  * Worker cannot provide. A dispatcher tested only against a stub command proves
  * the dispatcher works and says nothing about whether the bot does.
  */
@@ -70,9 +70,7 @@ describe('dispatchInteraction', () => {
     for (const [name, options] of cases) {
       const response = invoke(name, options)
       expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
-      // Either renderer is acceptable while the migration is in flight — the
-      // point of this gate is that every command produces *something*.
-      expect(response.data?.embeds?.[0] ?? response.data?.components?.[0]).toBeDefined()
+      expect(response.data?.components?.[0]).toMatchObject({ type: 17 })
     }
   })
 
@@ -93,12 +91,24 @@ describe('dispatchInteraction', () => {
     const response = invoke('nonexistent')
     // Matches the gateway bot's behaviour: a stale registry entry says so.
     expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
-    expect(response.data?.embeds?.[0]?.title).toBe('Error')
+    expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
   })
 
-  test('turns a bad roll into an error embed, not a throw', () => {
+  test('turns a bad roll into an error response, not a throw', () => {
     const response = invoke('roll', [{ name: 'notation', value: 'not-notation' }])
-    expect(response.data?.embeds?.[0]?.title).toBe('Error')
+    expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
+  })
+
+  test('an error is ephemeral and carries the V2 flag', () => {
+    const response = invoke('roll', [{ name: 'notation', value: 'not-notation' }])
+    expect(response.data?.flags).toBe(32768 | 64)
+  })
+
+  test('an error accent is distinct from every failure accent', () => {
+    // The embed version used 0xff0000, byte-identical to the failure colour of
+    // /blades, /pbta and /root — so a missed roll and a crash looked the same.
+    const response = invoke('roll', [{ name: 'notation', value: 'not-notation' }])
+    expect(JSON.stringify(response.data?.components)).toContain(String(0x992d22))
   })
 
   test('renders /help from the barrel, not from a gateway client', () => {
@@ -129,11 +139,11 @@ describe('dispatchInteraction', () => {
   })
 
   test('every command has a Worker renderer', () => {
-    // The parity gate. A new command added without either renderer would answer
-    // "not available on this deployment" in production, which is the kind of
-    // gap that only surfaces when someone tries the command.
+    // The parity gate. A new command added without a renderer would answer "not
+    // available on this deployment" in production, which is the kind of gap
+    // that only surfaces when someone tries the command.
     for (const command of commandList) {
-      expect(command.buildView ?? command.buildEmbed).toBeDefined()
+      expect(command.buildView).toBeDefined()
     }
   })
 
@@ -218,27 +228,12 @@ describe('dispatchInteraction', () => {
       expect(invokeView([{ name: 'hidden', value: true }]).data?.flags).toBe(32768 | 64)
     })
 
-    test('buildView wins when a command defines both renderers', () => {
-      const both: Command = {
-        data: commandList[0]!.data,
-        buildView,
-        buildEmbed: () => {
-          throw new Error('the embed path must not run when buildView exists')
-        }
-      }
-      const response = dispatchInteraction(
-        { type: 2, data: { name: 'probe' } },
-        new Map([['probe', both]])
-      ) as Rendered
-      expect(response.data?.components?.[0]).toMatchObject({ type: 17 })
-    })
-
-    test('a command with neither renderer still reports itself unavailable', () => {
+    test('a command with no renderer still reports itself unavailable', () => {
       const response = dispatchInteraction(
         { type: 2, data: { name: 'probe' } },
         new Map([['probe', { data: commandList[0]!.data }]])
       ) as Rendered
-      expect(response.data?.embeds?.[0]?.title).toBe('Error')
+      expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
     })
   })
 

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -1,4 +1,3 @@
-import type { EmbedBuilder } from '../../utils/builders.js'
 import type { Command, RollView } from '../../types.js'
 import type { CommandContext } from './context.js'
 
@@ -6,23 +5,10 @@ export type { CommandContext } from './context.js'
 export type { ViewFact } from './view.js'
 export { renderTrace, rollContainer } from './view.js'
 
-/**
- * Exactly one renderer, never neither.
- *
- * A union rather than two optional properties so the factory keeps the one
- * guarantee it has left: a command built through it cannot forget to render.
- * `buildView` is where every command is heading; `buildEmbed` remains until the
- * last one migrates.
- */
-type CreateGameCommandOptions =
-  | {
-      readonly data: Command['data']
-      readonly buildView: (context: CommandContext) => RollView
-    }
-  | {
-      readonly data: Command['data']
-      readonly buildEmbed: (context: CommandContext) => EmbedBuilder
-    }
+interface CreateGameCommandOptions {
+  readonly data: Command['data']
+  readonly buildView: (context: CommandContext) => RollView
+}
 
 /** Default message for the shared catch block: the error text, or a generic fallback. */
 export function defaultErrorMessage(error: unknown): string {
@@ -39,15 +25,13 @@ export function defaultErrorMessage(error: unknown): string {
  * every command, so what is left here is the pairing itself.
  *
  * Kept rather than inlined because it gives every command one declared shape,
- * and because `buildEmbed` is optional on `Command` while it is required here:
+ * and because `buildView` is optional on `Command` while it is required here:
  * a command built through this factory cannot omit its renderer.
  */
 export function createGameCommand(options: CreateGameCommandOptions): Command {
-  if ('buildView' in options) {
-    return { data: options.data, buildView: options.buildView }
-  }
+  const { data, buildView } = options
 
-  return { data: options.data, buildEmbed: options.buildEmbed }
+  return { data, buildView }
 }
 
 /** Formats a modifier with an explicit sign: positive values gain a leading `+`. */

--- a/apps/discord-bot/src/types.ts
+++ b/apps/discord-bot/src/types.ts
@@ -1,10 +1,10 @@
 import type { SlashCommandBuilder, SlashCommandOptionsOnlyBuilder } from 'discord.js'
-// Deliberately the portable builder, not discord.js's. discord.js does not
-// re-export @discordjs/builders verbatim — it *subclasses* EmbedBuilder, adding
-// `.length` and accepting hex-string colours. The two are therefore distinct
-// types, and a command that returns one cannot satisfy a signature demanding
-// the other. Since command renderers must run on workerd, the portable one wins.
-import type { ContainerBuilder, EmbedBuilder } from './utils/builders.js'
+// Deliberately the portable builders, not discord.js's. discord.js does not
+// re-export @discordjs/builders verbatim — it subclasses some of them — so the
+// two are distinct types, and a command returning one cannot satisfy a
+// signature demanding the other. Since command renderers must run on workerd,
+// the portable ones win.
+import type { ContainerBuilder } from './utils/builders.js'
 import type { CommandContext } from './commands/lib/context.js'
 
 /**
@@ -24,38 +24,22 @@ export type RollView = readonly ContainerBuilder[]
 export interface Command {
   data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder
   /**
-   * The transport-agnostic renderer — the whole of a command.
+   * The renderer — the whole of a command.
    *
-   * There used to be an `execute(interaction)` beside this: the discord.js
-   * entry point, which took a live gateway interaction and replied through it.
-   * The Worker is the only transport now, and it has no interaction to reply
-   * through — it returns a response body — so `buildEmbed` is what runs.
+   * There used to be a `buildEmbed` beside this, and before that an
+   * `execute(interaction)`. Both are gone: the Worker is the only transport and
+   * Components V2 is the only output shape, so a command builds containers and
+   * the dispatcher wraps them.
    *
-   * Still optional, and the Worker still checks: a command added without one
-   * must say "not available on this deployment" rather than have the dispatcher
-   * guess. Every command in the barrel currently has one, and
+   * Still optional, and the dispatcher still checks: a command added without
+   * one must say "not available on this deployment" rather than have the
+   * dispatcher guess. Every command in the barrel has one, and
    * `__tests__/worker/dispatch.test.ts` holds that line.
-   */
-  /**
-   * The Components V2 renderer — where every command is heading.
    *
-   * Present alongside `buildEmbed` on purpose: the dispatcher prefers this
-   * when a command defines it and falls back to the embed path otherwise, so
-   * commands migrate one file at a time with the bot shippable at every
-   * commit. Once every command defines `buildView`, `buildEmbed` and the
-   * fallback branch both go.
+   * `buildComponents` went with `buildEmbed`. It existed because an embed and
+   * its action row were separate fields on the response; under Components V2
+   * they are the same tree, and `/notation` — its only user — nests its select
+   * menu inside its container.
    */
   buildView?: (context: CommandContext) => RollView
-  /** @deprecated Superseded by `buildView`; removed once every command migrates. */
-  buildEmbed?: (context: CommandContext) => EmbedBuilder
-  /**
-   * Interactive components to attach alongside the embed, as raw API JSON.
-   *
-   * Only `/notation` uses this. Kept separate from `buildEmbed` rather than
-   * folded into a single "build the view" hook because nine of ten commands
-   * have no components at all, and widening their signature to carry an always-
-   * empty array is the kind of shared abstraction that gets filled in wrongly
-   * later.
-   */
-  buildComponents?: (context: CommandContext) => readonly unknown[]
 }

--- a/apps/discord-bot/src/utils/builders.ts
+++ b/apps/discord-bot/src/utils/builders.ts
@@ -14,8 +14,8 @@
  * tricks, and no second implementation.
  *
  * The version is pinned to the one discord.js itself depends on, so the classes
- * here are the same classes it would hand back. A drift there would produce
- * two `EmbedBuilder` identities in one process, which fails in a genuinely
+ * here are the same classes it would hand back. A drift there would produce two
+ * identities for the same builder in one process, which fails in a genuinely
  * confusing way.
  *
  * The rule this encodes: **command files import from here, never from
@@ -31,7 +31,6 @@ export {
   ActionRowBuilder,
   ButtonBuilder,
   ContainerBuilder,
-  EmbedBuilder,
   SectionBuilder,
   SeparatorBuilder,
   SlashCommandBuilder,

--- a/apps/discord-bot/src/utils/palette.ts
+++ b/apps/discord-bot/src/utils/palette.ts
@@ -102,3 +102,10 @@ export const FATE = {
 
 /** `/roll` and the informational commands. Brand identity, not an outcome. */
 export const BRAND = 0x7c3aed
+
+/**
+ * Errors. Deliberately distinct from every failure accent above: the embed
+ * version shared `0xff0000` with three commands' failure colour, so a missed
+ * roll and a validation crash were indistinguishable.
+ */
+export const ERROR = 0x992d22

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -12,7 +12,9 @@
  * alive, no second failure mode) and visibly faster — the user never sees a
  * "thinking…" state for work that was already done.
  */
-import { MessageFlags } from '../utils/builders.js'
+import { ContainerBuilder, MessageFlags, TextDisplayBuilder } from '../utils/builders.js'
+import { FOOTER_ATTRIBUTION } from '../utils/constants.js'
+import { ERROR } from '../utils/palette.js'
 import { optionsFromPayload } from '../commands/lib/context.js'
 import { defaultErrorMessage } from '../commands/lib/index.js'
 import { buildNotationView, NOTATION_SELECT_ID } from '../commands/lib/notationView.js'
@@ -104,13 +106,34 @@ function viewResponse(view: RollView, hidden: boolean): unknown {
   }
 }
 
+/**
+ * The error surface, as a container like everything else.
+ *
+ * Two things were wrong with the embed version beyond its shape. Its `0xff0000`
+ * was byte-identical to the failure accent of `/blades`, `/pbta` and `/root`,
+ * so a missed roll and a crash looked the same; it uses a distinct dark red
+ * now. And it was the only message in the bot with no footer, because it was a
+ * raw object literal that never went near the shared constant.
+ *
+ * Always ephemeral, regardless of the `hidden` option: an error is for the
+ * person who typed the command, not the channel.
+ */
 function errorResponse(message: string): unknown {
   return {
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      embeds: [{ title: 'Error', description: message, color: 0xff0000 }],
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
       allowed_mentions: NO_MENTIONS,
-      flags: MessageFlags.Ephemeral
+      components: [
+        new ContainerBuilder()
+          .setAccentColor(ERROR)
+          .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent('## Something went wrong'),
+            new TextDisplayBuilder().setContent(message),
+            new TextDisplayBuilder().setContent(`-# ${FOOTER_ATTRIBUTION}`)
+          )
+          .toJSON()
+      ]
     }
   }
 }
@@ -175,7 +198,7 @@ export function dispatchInteraction(
     return errorResponse(`Unknown command: \`/${name}\`. It may have been removed.`)
   }
 
-  if (command.buildView === undefined && command.buildEmbed === undefined) {
+  if (command.buildView === undefined) {
     return errorResponse(`\`/${name}\` is not available on this deployment yet.`)
   }
 
@@ -185,30 +208,7 @@ export function dispatchInteraction(
     const context = { options, userDisplayName: resolveDisplayName(payload) }
     const hidden = options.getBoolean('hidden') ?? false
 
-    // Components V2 first. A command that defines `buildView` never touches the
-    // embed path, and the two are mutually exclusive per message — the V2 flag
-    // forbids `embeds` outright, so there is no blending them.
-    if (command.buildView !== undefined) {
-      return viewResponse(command.buildView(context), hidden)
-    }
-
-    // Legacy embed path. Deleted once every command defines `buildView`.
-    if (command.buildEmbed === undefined) {
-      return errorResponse(`\`/${name}\` is not available on this deployment yet.`)
-    }
-
-    const embed = command.buildEmbed(context)
-    const components = command.buildComponents?.(context)
-
-    return {
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: {
-        allowed_mentions: NO_MENTIONS,
-        embeds: [embed.toJSON()],
-        ...(components !== undefined && components.length > 0 ? { components } : {}),
-        ...(hidden ? { flags: MessageFlags.Ephemeral } : {})
-      }
-    }
+    return viewResponse(command.buildView(context), hidden)
   } catch (error) {
     return errorResponse(defaultErrorMessage(error))
   }


### PR DESCRIPTION
## Summary

Every command is on `buildView`, so the seam from #1240 has done its job and closes here. Leaving both renderers alive would mean two ways to build a message, two test styles, and a "which does this command use?" question forever.

**Stacked on #1244.** Review order: #1239 → #1240 → #1241 → #1242 → #1243 → #1244 → this.

## Removed

- `Command.buildEmbed` and `Command.buildComponents`
- The dispatcher's fallback branch — `dispatchInteraction` now has one path
- `EmbedBuilder` from the portable barrel
- The union in `createGameCommand`, back to a plain interface now there's one renderer shape again

## The error response becomes a container

This fixes two things the audit found beyond its shape:

- Its `0xff0000` was **byte-identical to the failure accent** of `/blades`, `/pbta` and `/root`, so a missed roll and a validation crash looked the same. It has its own dark red now.
- It was **the only message in the bot without a footer**, because it was a raw object literal that never went near the shared constant.

It stays unconditionally ephemeral: an error is for the person who typed the command, not the channel.

## Gates tighten

The barrel and dispatcher parity tests go back from "either renderer" to `buildView`, so a command added without one fails at the barrel rather than in production.

## Docs

`apps/discord-bot/CLAUDE.md` described `buildEmbed(context) => EmbedBuilder` as the contract, which would have been actively misleading after this. Updated: the new contract, how to build a view (`rollContainer`, `renderTrace`, the palette), the two Components V2 constraints worth knowing up front (no inline field grid; 100-character `custom_id`), and the two testing traps this migration actually hit —

- `bun test` does **not** typecheck, so a test can pass while violating `exactOptionalPropertyTypes`
- `mock.module` leaks across test files **even under `--isolate`**, so a test relying on an un-mocked import can pass alone and fail in the suite

Both cost me real time in this stack; they're written down so they don't cost the next person the same.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

Breaking only *within the private bot*: `Command.buildEmbed` is removed from an interface nothing outside `apps/discord-bot` consumes. Nothing published changes.

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

- **`ERROR` returns to the palette here.** It was added in #1243 and removed in the same PR because `knip` flagged it as unused — the error container is its first consumer. Worth knowing why it appears twice in the stack's history.
- The one remaining gap is the Reroll buttons, still unwired. Next and last PR.

## Checklist

- [x] `bun run check:all` passes for the touched package; `knip` clean
- [x] Tests cover the change — 133 pass, up from 132; new coverage for the error container's ephemerality, its V2 flag, and its distinct accent
- [x] Bundle size limits respected (no new dependencies; this removes one builder from the bundle)
- [x] Public API changes reflected in the matching docs — `apps/discord-bot/CLAUDE.md` updated
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_