### PR TITLE
feat(discord-bot): wire up the reroll buttons

### DIFF
--- a/apps/discord-bot/CLAUDE.md
+++ b/apps/discord-bot/CLAUDE.md
@@ -42,7 +42,7 @@ apps/discord-bot/
       roll.ts            # /roll — generic notation roller
       root.ts            # /root — Root RPG
       salvageunion.ts    # /salvageunion — pointer to the SURef bot (rolls nothing)
-      lib/               # Shared command scaffolding (context, notation view, factory)
+      lib/               # Shared scaffolding (context, view renderer, reroll codec, factory)
     utils/
       builders.ts        # PORTABLE Discord primitives — safe on workerd. Commands import here.
       palette.ts         # Accent colours and outcome glyphs — the visual vocabulary
@@ -173,6 +173,18 @@ layout, and the `-#` subtext footer that replaces the embed footer Components V2
 Components V2 has no `inline` field grid, so label/value pairs go through `renderFacts` as one
 line; and a `custom_id` caps at 100 characters, so a reroll button carrying long notation is
 dropped rather than truncated (Discord rejects the whole message otherwise).
+
+**Reroll buttons.** `commands/lib/reroll.ts` encodes the command name and its options into the
+button's `custom_id` — the only state channel a stateless Worker has — and decodes it back into
+a `CommandContext`, so a reroll runs the same `buildView` the slash command does. Pass
+`encodeReroll('<command>', { ...options })` to `rollContainer`; it returns `undefined` when the
+result would exceed 100 characters, and the button is then omitted rather than truncated (a
+truncated id would decode into a *different roll*).
+
+A reroll answers with a **new message (type 4), never an edit (type 7)**. A Worker cannot tell
+whether the clicker is the person who rolled without spending ~19 of those 100 characters on
+their user id, and an edit would let a bystander silently overwrite someone else's result. Type 7
+stays for genuinely stateless view-switching, which is what `/notation`'s selector does.
 
 All game commands import their `roll()` from the corresponding `@randsum/games/<shortcode>`
 subpath. The exception is `/salvageunion`, which rolls nothing: Salvage Union moved to the SURef

--- a/apps/discord-bot/__tests__/commands/lib/reroll.test.ts
+++ b/apps/discord-bot/__tests__/commands/lib/reroll.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  CUSTOM_ID_LIMIT,
+  decodeReroll,
+  encodeReroll,
+  isRerollId
+} from '../../../src/commands/lib/reroll.js'
+
+describe('encodeReroll', () => {
+  test('encodes the command and its options', () => {
+    expect(encodeReroll('roll', { notation: '4d6L' })).toBe('r:roll:notation=4d6L')
+  })
+
+  test('omits absent options rather than encoding empties', () => {
+    expect(encodeReroll('fifth', { modifier: 2, dc: null, rolling_with: undefined })).toBe(
+      'r:fifth:modifier=2'
+    )
+  })
+
+  test('omits false booleans, which decode identically and cost characters', () => {
+    expect(encodeReroll('blades', { dice: 3, hidden: false })).toBe('r:blades:dice=3')
+  })
+
+  test('keeps true booleans, which do not', () => {
+    expect(encodeReroll('blades', { dice: 3, hidden: true })).toBe('r:blades:dice=3&hidden=true')
+  })
+
+  test('escapes values that would otherwise break the encoding', () => {
+    const id = encodeReroll('roll', { notation: '2d6+3[fire & ice]' })
+    expect(id).toBeDefined()
+    expect(decodeReroll(id!)?.options.getString('notation')).toBe('2d6+3[fire & ice]')
+  })
+
+  test('returns undefined rather than a truncated id when over the limit', () => {
+    // A truncated id would decode into a *different roll*, which is worse than
+    // no button — and Discord rejects the whole message over the limit anyway.
+    const long = `2d6+3[${'a'.repeat(120)}]`
+    expect(encodeReroll('roll', { notation: long })).toBeUndefined()
+  })
+
+  test('an id at exactly the limit is kept', () => {
+    const padding = 'a'.repeat(CUSTOM_ID_LIMIT - 'r:roll:notation='.length)
+    const id = encodeReroll('roll', { notation: padding })
+    expect(id).toHaveLength(CUSTOM_ID_LIMIT)
+  })
+})
+
+describe('decodeReroll', () => {
+  test('round-trips through encode', () => {
+    const id = encodeReroll('pbta', { stat: 2, forward: -1, rolling_with: 'Advantage' })
+    const target = decodeReroll(id!)
+
+    expect(target?.commandName).toBe('pbta')
+    expect(target?.options.getInteger('stat')).toBe(2)
+    expect(target?.options.getInteger('forward')).toBe(-1)
+    expect(target?.options.getString('rolling_with')).toBe('Advantage')
+  })
+
+  test('reports the hidden flag so a reroll stays as private as the original', () => {
+    expect(decodeReroll(encodeReroll('roll', { notation: '1d20', hidden: true })!)?.hidden).toBe(
+      true
+    )
+    expect(decodeReroll(encodeReroll('roll', { notation: '1d20' })!)?.hidden).toBe(false)
+  })
+
+  test('an absent option reads as null, exactly as an unset slash option does', () => {
+    const target = decodeReroll('r:fifth:modifier=2')
+    expect(target?.options.getInteger('dc')).toBeNull()
+    expect(target?.options.getString('rolling_with')).toBeNull()
+    expect(target?.options.getBoolean('hidden')).toBeNull()
+  })
+
+  test('an unparseable integer degrades to null rather than NaN', () => {
+    // A corrupted id should reroll with defaults, not render "NaN" at a player.
+    expect(decodeReroll('r:fifth:modifier=abc')?.options.getInteger('modifier')).toBeNull()
+  })
+
+  test('rejects ids that are not rerolls at all', () => {
+    expect(decodeReroll('notation-category')).toBeUndefined()
+    expect(isRerollId('notation-category')).toBe(false)
+  })
+
+  test('rejects a malformed reroll id rather than guessing', () => {
+    expect(decodeReroll('r:')).toBeUndefined()
+    expect(decodeReroll('r:roll')).toBeUndefined()
+    expect(decodeReroll('r::notation=2d6')).toBeUndefined()
+  })
+})

--- a/apps/discord-bot/__tests__/commands/lib/view.test.ts
+++ b/apps/discord-bot/__tests__/commands/lib/view.test.ts
@@ -13,12 +13,8 @@
  */
 import { describe, expect, test } from 'bun:test'
 import type { TraceableRollRecord } from '@randsum/roller/trace'
-import {
-  CUSTOM_ID_LIMIT,
-  renderFacts,
-  renderTrace,
-  rollContainer
-} from '../../../src/commands/lib/view.js'
+import { CUSTOM_ID_LIMIT } from '../../../src/commands/lib/reroll.js'
+import { renderFacts, renderTrace, rollContainer } from '../../../src/commands/lib/view.js'
 import { accentsOf, buttonIdsOf, linesOf, textOf } from '../../lib/view.js'
 
 /** Real `roll('4d6L')` output — one die dropped. */

--- a/apps/discord-bot/__tests__/commands/roll.test.ts
+++ b/apps/discord-bot/__tests__/commands/roll.test.ts
@@ -302,7 +302,7 @@ describe('rollCommand', () => {
         }
       ]
     }))
-    expect(buttonIdsOf(render('2d6'))).toEqual(['r:2d6'])
+    expect(buttonIdsOf(render('2d6'))).toEqual(['r:roll:notation=2d6'])
   })
 
   test('an over-long notation drops the reroll button rather than sending an invalid id', () => {

--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -237,6 +237,74 @@ describe('dispatchInteraction', () => {
     })
   })
 
+  describe('reroll buttons', () => {
+    test('a reroll re-runs the command from its encoded state', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:roll:notation=4d6L' } },
+        commands
+      ) as Rendered
+      expect(response.data?.components?.[0]).toMatchObject({ type: 17 })
+    })
+
+    test('a reroll posts a NEW message rather than editing the original', () => {
+      // Type 7 would let a bystander's click silently overwrite someone else's
+      // result, since a stateless Worker cannot tell who is clicking without
+      // spending ~19 of the 100 custom_id characters on a user id.
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:roll:notation=1d20' } },
+        commands
+      ) as Rendered
+      expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+      expect(response.type).not.toBe(InteractionResponseType.UpdateMessage)
+    })
+
+    test('a reroll of a hidden roll stays hidden', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:blades:dice=3&hidden=true' } },
+        commands
+      ) as Rendered
+      expect(response.data?.flags).toBe(32768 | 64)
+    })
+
+    test('a reroll of a public roll stays public', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:blades:dice=3' } },
+        commands
+      ) as Rendered
+      expect(response.data?.flags).toBe(32768)
+    })
+
+    test('a button for a removed command says so instead of failing silently', () => {
+      // Buttons outlive deployments: nothing expires them, so a months-old
+      // message can still be clicked.
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:noSuchCommand:x=1' } },
+        commands
+      ) as Rendered
+      expect(JSON.stringify(response.data?.components)).toContain('no longer available')
+    })
+
+    test('a roll that throws on reroll renders the error, not a crash', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:blades:dice=99' } },
+        commands
+      ) as Rendered
+      expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
+    })
+
+    test('a malformed reroll id is left to the caller, as before', () => {
+      expect(dispatchInteraction({ type: 3, data: { custom_id: 'r:' } }, commands)).toBeUndefined()
+    })
+
+    test('the notation selector still works alongside reroll ids', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'notation-category', values: ['Filter'] } },
+        commands
+      ) as Rendered
+      expect(response.type).toBe(InteractionResponseType.UpdateMessage)
+    })
+  })
+
   describe('mention suppression', () => {
     // Components V2 TextDisplay content is mention-parsed like message content,
     // and `/roll`'s annotation is free user text that lands verbatim in a public
@@ -253,6 +321,14 @@ describe('dispatchInteraction', () => {
 
     test('an error response suppresses mentions too', () => {
       const response = invoke('roll', [{ name: 'notation', value: 'not-notation' }])
+      expect(response.data?.allowed_mentions).toEqual({ parse: [] })
+    })
+
+    test('a reroll response suppresses mentions', () => {
+      const response = dispatchInteraction(
+        { type: 3, data: { custom_id: 'r:roll:notation=1d20' } },
+        commands
+      ) as Rendered
       expect(response.data?.allowed_mentions).toEqual({ parse: [] })
     })
 

--- a/apps/discord-bot/src/commands/blades.ts
+++ b/apps/discord-bot/src/commands/blades.ts
@@ -3,6 +3,7 @@ import { SlashCommandBuilder } from '../utils/builders.js'
 import { BLADES, GLYPH } from '../utils/palette.js'
 import {
   createGameCommand,
+  encodeReroll,
   getInitialRolls,
   getKeptRolls,
   markKeptRolls,
@@ -55,6 +56,9 @@ function buildBladesView(context: CommandContext): RollView {
   const pool =
     dice === 0 ? '0 dice — roll two, take the worst' : `${dice} ${dice === 1 ? 'die' : 'dice'}`
 
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('blades', { dice, hidden })
+
   return [
     rollContainer({
       accent: outcome.accent,
@@ -66,7 +70,7 @@ function buildBladesView(context: CommandContext): RollView {
       ],
       body: [markKeptRolls(initialRolls, keptRolls)],
       derivation: `${initialRolls.length}d6 → ${decidingDie}`,
-      rerollId: `r:blades:${dice}`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -1,7 +1,12 @@
 import { roll } from '@randsum/games/daggerheart'
 import { SlashCommandBuilder } from '../utils/builders.js'
 import { DAGGERHEART, GLYPH } from '../utils/palette.js'
-import { createGameCommand, formatSignedModifier, rollContainer } from './lib/index.js'
+import {
+  createGameCommand,
+  encodeReroll,
+  formatSignedModifier,
+  rollContainer
+} from './lib/index.js'
 import type { CommandContext, ViewFact } from './lib/index.js'
 import type { Command, RollView } from '../types.js'
 
@@ -81,6 +86,16 @@ function buildDhView(context: CommandContext): RollView {
   if (modifier !== 0) facts.push({ label: 'Modifier', value: formatSignedModifier(modifier) })
   facts.push({ label: 'Total', value: String(result.total) })
 
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('dh', {
+    modifier,
+    difficulty,
+    rolling_with: rollingWith,
+    amplify_hope: amplifyHope,
+    amplify_fear: amplifyFear,
+    hidden
+  })
+
   return [
     rollContainer({
       accent,
@@ -91,7 +106,7 @@ function buildDhView(context: CommandContext): RollView {
         `**Hope ${hopeSides}**  ${result.details.hope.roll}   **Fear ${fearSides}**  ${result.details.fear.roll}`
       ],
       derivation: `${hopeSides} ${result.details.hope.roll} / ${fearSides} ${result.details.fear.roll} ${formatSignedModifier(modifier)} = ${result.total}`,
-      rerollId: `r:dh:${modifier}:${difficulty ?? ''}:${rollingWith ?? ''}:${amplifyHope ? 1 : 0}:${amplifyFear ? 1 : 0}`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -4,6 +4,7 @@ import { SlashCommandBuilder } from '../utils/builders.js'
 import { FATE, GLYPH } from '../utils/palette.js'
 import {
   createGameCommand,
+  encodeReroll,
   formatSignedModifier,
   getInitialRolls,
   rollContainer
@@ -100,6 +101,9 @@ function buildFateView(context: CommandContext): RollView {
   if (skill !== 0) facts.push({ label: 'Skill', value: formatSignedModifier(skill) })
   facts.push({ label: 'Total', value: formatSignedModifier(result.total) })
 
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('fate', { skill, opposition, hidden })
+
   const headline = `${rung.label} (${formatSignedModifier(result.total)})`
 
   if (opposition !== null) {
@@ -124,7 +128,7 @@ function buildFateView(context: CommandContext): RollView {
         facts,
         body: [dice.map(fateDieTile).join(' ')],
         derivation: `4dF ${formatSignedModifier(skill)} = ${formatSignedModifier(result.total)} vs ${formatSignedModifier(opposition)}`,
-        rerollId: `r:fate:${skill}:${opposition}`
+        ...(rerollId !== undefined ? { rerollId } : {})
       })
     ]
   }
@@ -136,7 +140,7 @@ function buildFateView(context: CommandContext): RollView {
       facts,
       body: [dice.map(fateDieTile).join(' ')],
       derivation: `4dF ${formatSignedModifier(skill)} = ${formatSignedModifier(result.total)}`,
-      rerollId: `r:fate:${skill}:`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/commands/fifth.ts
+++ b/apps/discord-bot/src/commands/fifth.ts
@@ -3,6 +3,7 @@ import { SlashCommandBuilder } from '../utils/builders.js'
 import { FIFTH, GLYPH } from '../utils/palette.js'
 import {
   createGameCommand,
+  encodeReroll,
   formatSignedModifier,
   getInitialRolls,
   getKeptRolls,
@@ -86,6 +87,9 @@ function buildFifthView(context: CommandContext): RollView {
   const dice = dropped ? markKeptRolls(initialRolls, keptRolls) : initialRolls.join(', ')
   const label = rollingWith !== null ? `2d20, ${rollingWith}` : '1d20'
 
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('fifth', { modifier, dc, rolling_with: rollingWith, hidden })
+
   return [
     rollContainer({
       accent,
@@ -94,7 +98,7 @@ function buildFifthView(context: CommandContext): RollView {
       facts,
       body: [`**${label}**  ${dice}`],
       derivation: `${label} ${formatSignedModifier(modifier)} = ${result.total}`,
-      rerollId: `r:fifth:${modifier}:${dc ?? ''}:${rollingWith ?? ''}`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -4,6 +4,7 @@ import type { CommandContext } from './context.js'
 export type { CommandContext } from './context.js'
 export type { ViewFact } from './view.js'
 export { renderTrace, rollContainer } from './view.js'
+export { decodeReroll, encodeReroll, isRerollId } from './reroll.js'
 
 interface CreateGameCommandOptions {
   readonly data: Command['data']

--- a/apps/discord-bot/src/commands/lib/reroll.ts
+++ b/apps/discord-bot/src/commands/lib/reroll.ts
@@ -1,0 +1,129 @@
+/**
+ * Reroll state, encoded into a button's `custom_id`.
+ *
+ * A stateless Worker has nowhere to keep "what was rolled" between the original
+ * message and a click on its button — no session, no collector, no storage
+ * binding. Discord gives exactly one channel for it: `custom_id`, **1 to 100
+ * characters**. That is the whole budget, and exceeding it does not truncate,
+ * it makes Discord reject the entire message.
+ *
+ * So the encoding is the command name plus its options, and the decoder rebuilds
+ * a `CommandContext` from them and calls the same `buildView` the slash command
+ * would. No command needs a second code path for being rerolled.
+ *
+ * ## Why a reroll posts a NEW message
+ *
+ * The obvious implementation is `UPDATE_MESSAGE` (type 7), editing the roll in
+ * place. It is wrong here. A Worker cannot tell whether the person clicking is
+ * the person who rolled without spending ~19 of the 100 characters on their user
+ * id — and with type 7, a bystander's click would silently overwrite someone
+ * else's result. A new message per reroll sidesteps ownership entirely and
+ * leaves the channel readable as a transcript, which is what a table wants from
+ * a dice bot anyway.
+ */
+import type { CommandOptions } from './context.js'
+
+/** Discord's hard limit. A longer id gets the whole message rejected. */
+export const CUSTOM_ID_LIMIT = 100
+
+/** Marks a component as a reroll, and namespaces it away from other controls. */
+const PREFIX = 'r:'
+
+export interface RerollTarget {
+  readonly commandName: string
+  readonly options: CommandOptions
+  readonly hidden: boolean
+}
+
+/**
+ * Encode a reroll id, or `undefined` when it will not fit.
+ *
+ * Returning `undefined` rather than a truncated id is deliberate: a truncated
+ * id would decode into a *different roll*, which is worse than no button.
+ * Callers pass the result straight to `rollContainer`, which omits the button
+ * when it is absent.
+ */
+export function encodeReroll(
+  commandName: string,
+  options: Readonly<Record<string, string | number | boolean | null | undefined>>
+): string | undefined {
+  const params = new URLSearchParams()
+  for (const [name, value] of Object.entries(options)) {
+    // `false` is dropped alongside null and empty: every boolean option in this
+    // bot defaults to false, so omitting it decodes identically and buys back
+    // characters against the 100-character ceiling. A boolean whose default was
+    // true would need encoding explicitly.
+    if (value === null || value === undefined || value === '' || value === false) continue
+    params.set(name, String(value))
+  }
+
+  const encoded = `${PREFIX}${commandName}:${params.toString()}`
+  return encoded.length <= CUSTOM_ID_LIMIT ? encoded : undefined
+}
+
+/** True when a component id belongs to this module. */
+export function isRerollId(customId: string): boolean {
+  return customId.startsWith(PREFIX)
+}
+
+/**
+ * Read options back out of an encoded id.
+ *
+ * Coerces on read rather than storing types, because the option's declared type
+ * already says what it is: `getInteger` is only ever called for an option
+ * Discord validated as an integer. An unparseable value yields `null`, which is
+ * exactly what an absent option yields — so a corrupted id degrades to
+ * "rerolled with defaults" rather than throwing at the user.
+ */
+export function optionsFromParams(params: URLSearchParams): CommandOptions {
+  function getString(name: string, required: true): string
+  function getString(name: string, required?: boolean): string | null
+  function getString(name: string): string | null {
+    return params.get(name)
+  }
+
+  function getInteger(name: string, required: true): number
+  function getInteger(name: string, required?: boolean): number | null
+  function getInteger(name: string): number | null {
+    const raw = params.get(name)
+    if (raw === null) return null
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+
+  function getBoolean(name: string, required: true): boolean
+  function getBoolean(name: string, required?: boolean): boolean | null
+  function getBoolean(name: string): boolean | null {
+    const raw = params.get(name)
+    if (raw === null) return null
+    return raw === 'true'
+  }
+
+  return { getString, getInteger, getBoolean }
+}
+
+/**
+ * Decode a reroll id, or `undefined` if it is not one this bot can serve.
+ *
+ * A malformed id is not an error to surface: the likeliest source is a button
+ * on a months-old message from an older deployment, and the honest answer there
+ * is the dispatcher's "unknown component" path rather than a stack trace.
+ */
+export function decodeReroll(customId: string): RerollTarget | undefined {
+  if (!isRerollId(customId)) return undefined
+
+  const rest = customId.slice(PREFIX.length)
+  const separator = rest.indexOf(':')
+  if (separator === -1) return undefined
+
+  const commandName = rest.slice(0, separator)
+  if (commandName.length === 0) return undefined
+
+  const params = new URLSearchParams(rest.slice(separator + 1))
+
+  return {
+    commandName,
+    options: optionsFromParams(params),
+    hidden: params.get('hidden') === 'true'
+  }
+}

--- a/apps/discord-bot/src/commands/lib/view.ts
+++ b/apps/discord-bot/src/commands/lib/view.ts
@@ -32,13 +32,7 @@ import {
   TextDisplayBuilder
 } from '../../utils/builders.js'
 import { FOOTER_ATTRIBUTION } from '../../utils/constants.js'
-
-/**
- * Discord caps a `custom_id` at 100 characters and rejects the whole message
- * when a component exceeds it — so a reroll button carrying long notation has
- * to be dropped rather than truncated.
- */
-export const CUSTOM_ID_LIMIT = 100
+import { CUSTOM_ID_LIMIT } from './reroll.js'
 
 /**
  * A single Text Display caps at 4000 characters, and `setContent` throws rather

--- a/apps/discord-bot/src/commands/pbta.ts
+++ b/apps/discord-bot/src/commands/pbta.ts
@@ -3,6 +3,7 @@ import { SlashCommandBuilder } from '../utils/builders.js'
 import { GLYPH, PBTA } from '../utils/palette.js'
 import {
   createGameCommand,
+  encodeReroll,
   formatSignedModifier,
   getInitialRolls,
   getKeptRolls,
@@ -69,6 +70,15 @@ function buildPbtaView(context: CommandContext): RollView {
   const dropped = initialRolls.length > keptRolls.length
   const dice = dropped ? markKeptRolls(initialRolls, keptRolls) : initialRolls.join(', ')
 
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('pbta', {
+    stat,
+    forward,
+    ongoing,
+    rolling_with: rollingWith,
+    hidden
+  })
+
   return [
     rollContainer({
       accent: outcome.accent,
@@ -83,7 +93,7 @@ function buildPbtaView(context: CommandContext): RollView {
           : `**2d6**  ${dice}`
       ],
       derivation: `${result.details.diceTotal} ${formatSignedModifier(result.total - result.details.diceTotal)} = ${result.total}`,
-      rerollId: `r:pbta:${stat}:${forward}:${ongoing}:${rollingWith ?? ''}`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -3,7 +3,7 @@ import type { TraceableRollRecord } from '@randsum/roller/trace'
 import { notation as createNotation } from '@randsum/roller/validate'
 import { SlashCommandBuilder } from '../utils/builders.js'
 import { BRAND } from '../utils/palette.js'
-import { createGameCommand, renderTrace, rollContainer } from './lib/index.js'
+import { createGameCommand, encodeReroll, renderTrace, rollContainer } from './lib/index.js'
 import type { CommandContext } from './lib/index.js'
 import type { Command, RollView } from '../types.js'
 
@@ -96,9 +96,9 @@ function buildRollView(context: CommandContext): RollView {
   const pools = fitPools(result.rolls.slice(0, MAX_POOLS), multiple)
 
   // The whole roll re-rolls, not one pool, so the button belongs on the first
-  // container only. `createNotation` has already validated the string, so it is
-  // safe to round-trip — the length guard lives in `rollContainer`.
-  const rerollId = `r:${notationString}`
+  // container only. Long notation simply gets no button — see `encodeReroll`.
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('roll', { notation: notationString, hidden })
 
   const containers = pools.map((record, index) => {
     const description = (record.description ?? []).join(' · ')
@@ -112,7 +112,7 @@ function buildRollView(context: CommandContext): RollView {
       ...(description.length > 0 ? { consequence: description } : {}),
       body: renderTrace(record),
       derivation: multiple ? `Pool ${index + 1} of ${result.rolls.length}` : notationString,
-      ...(index === 0 ? { rerollId } : {})
+      ...(index === 0 && rerollId !== undefined ? { rerollId } : {})
     })
   })
 

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -3,6 +3,7 @@ import { SlashCommandBuilder } from '../utils/builders.js'
 import { GLYPH, ROOT } from '../utils/palette.js'
 import {
   createGameCommand,
+  encodeReroll,
   formatSignedModifier,
   getInitialRolls,
   getKeptRolls,
@@ -63,6 +64,14 @@ function buildRootView(context: CommandContext): RollView {
   // "<username> used /root" directly above every response, so the old
   // "Alex rolled a Weak Hit" title repeated it — and made this the one command
   // whose title shape differed from its nine siblings.
+  const hidden = context.options.getBoolean('hidden') ?? false
+  const rerollId = encodeReroll('root', {
+    modifier: bonus,
+    stat,
+    rolling_with: rollingWith,
+    hidden
+  })
+
   return [
     rollContainer({
       accent: outcome.accent,
@@ -71,7 +80,7 @@ function buildRootView(context: CommandContext): RollView {
       facts,
       body: [dropped ? `**3d6, keep 2**  ${dice}` : `**2d6**  ${dice}`],
       derivation: `2d6 ${formatSignedModifier(bonus)} = ${result.total}`,
-      rerollId: `r:root:${bonus}:${stat ?? ''}:${rollingWith ?? ''}`
+      ...(rerollId !== undefined ? { rerollId } : {})
     })
   ]
 }

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -16,7 +16,7 @@ import { ContainerBuilder, MessageFlags, TextDisplayBuilder } from '../utils/bui
 import { FOOTER_ATTRIBUTION } from '../utils/constants.js'
 import { ERROR } from '../utils/palette.js'
 import { optionsFromPayload } from '../commands/lib/context.js'
-import { defaultErrorMessage } from '../commands/lib/index.js'
+import { decodeReroll, defaultErrorMessage, isRerollId } from '../commands/lib/index.js'
 import { buildNotationView, NOTATION_SELECT_ID } from '../commands/lib/notationView.js'
 import type { Command, RollView } from '../types.js'
 
@@ -139,6 +139,43 @@ function errorResponse(message: string): unknown {
 }
 
 /**
+ * Re-run a command from the state encoded in a reroll button's `custom_id`.
+ *
+ * Answers with a NEW message (type 4) rather than editing the original (type
+ * 7). A Worker cannot tell whether the clicker is the person who rolled without
+ * spending ~19 of the 100 available characters on their user id, and an edit
+ * would let a bystander silently overwrite someone else's result. A new message
+ * also leaves the channel readable as a transcript.
+ *
+ * The reroll runs the same `buildView` the slash command does — there is no
+ * second rendering path to keep in step.
+ */
+function dispatchReroll(
+  customId: string,
+  payload: InteractionPayload,
+  commands: ReadonlyMap<string, Command>
+): unknown {
+  const target = decodeReroll(customId)
+  if (target === undefined) return undefined
+
+  const command = commands.get(target.commandName)
+  if (command?.buildView === undefined) {
+    // A button from an older deployment whose command has since been removed.
+    return errorResponse(`\`/${target.commandName}\` is no longer available.`)
+  }
+
+  try {
+    const view = command.buildView({
+      options: target.options,
+      userDisplayName: resolveDisplayName(payload)
+    })
+    return viewResponse(view, target.hidden)
+  } catch (error) {
+    return errorResponse(defaultErrorMessage(error))
+  }
+}
+
+/**
  * Handle a message-component interaction.
  *
  * Where a gateway bot keeps a collector alive on an open socket, each click
@@ -151,10 +188,18 @@ function errorResponse(message: string): unknown {
  * Responds with UpdateMessage (7), which edits the existing message in place,
  * matching the gateway path's `.update()` rather than posting a new reply.
  */
-function dispatchComponent(payload: InteractionPayload): unknown {
-  if (payload.data?.custom_id !== NOTATION_SELECT_ID) return undefined
+function dispatchComponent(
+  payload: InteractionPayload,
+  commands: ReadonlyMap<string, Command>
+): unknown {
+  const customId = payload.data?.custom_id
+  if (customId === undefined) return undefined
 
-  const view = buildNotationView(payload.data.values?.[0])
+  if (isRerollId(customId)) return dispatchReroll(customId, payload, commands)
+
+  if (customId !== NOTATION_SELECT_ID) return undefined
+
+  const view = buildNotationView(payload.data?.values?.[0])
   return {
     type: InteractionResponseType.UpdateMessage,
     data: {
@@ -183,7 +228,7 @@ export function dispatchInteraction(
   }
 
   if (payload.type === InteractionType.MessageComponent) {
-    return dispatchComponent(payload)
+    return dispatchComponent(payload, commands)
   }
 
   if (payload.type !== InteractionType.ApplicationCommand) return undefined


### PR DESCRIPTION
## Summary

The last PR in the stack, and it closes a gap the earlier ones opened: the Reroll buttons have been *rendered* since #1242, but nothing served the click. `dispatchComponent` recognised only the notation selector and returned `undefined` for everything else, which the Worker turns into an **HTTP 400 with no user-visible message**.

**Stacked on #1245.** Review order: #1239 → #1240 → #1241 → #1242 → #1243 → #1244 → #1245 → this.

## State lives in the `custom_id`, because there is nowhere else

A stateless Worker keeps nothing between the original message and a click on its button — no session, no collector, no storage binding — and Discord gives exactly one channel for it: **1 to 100 characters**. `commands/lib/reroll.ts` encodes the command name plus its options and decodes them back into a `CommandContext`, so a reroll runs the same `buildView` the slash command does. No command needs a second code path for being rerolled.

```
r:roll:notation=4d6L
r:pbta:stat=2&forward=-1&rolling_with=Advantage
```

Over the limit, `encodeReroll` returns `undefined` and the button is omitted. **Truncating would be worse than useless** — a truncated id decodes into a *different roll*, and Discord rejects the entire message over the ceiling anyway. `false` booleans are dropped alongside nulls, since every boolean option here defaults to false: it decodes identically and buys back characters.

## A reroll posts a NEW message (type 4), never an edit (type 7)

This is the design decision worth reviewing. Editing in place is the obvious implementation and it's wrong here: a Worker cannot tell whether the clicker is the person who rolled without spending ~19 of the 100 characters on their user id, and with an edit **a bystander's click would silently overwrite someone else's result**. A new message sidesteps ownership entirely and leaves the channel readable as a transcript, which is what a table wants from a dice bot.

Type 7 stays for genuinely stateless view-switching — `/notation`'s selector, which is unaffected and still covered.

## Degradations, not failures

Nothing expires a button, so a months-old message can still be clicked:

- A button whose command has since been removed answers "`/x` is no longer available" rather than a silent 400.
- A corrupted value decodes to `null` — the same thing an unset option yields — so the roll uses defaults rather than rendering `NaN` at a player.
- The hidden flag round-trips, so rerolling an ephemeral roll stays ephemeral rather than posting a private result into the channel.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/discord-bot`
- [ ] Infra / CI / tooling

## Notes for review

- **The type-4 versus type-7 choice is the one I'd most want a second opinion on.** If you'd rather rerolls edit in place, the ownership problem needs solving first — either by spending the characters on a user id, or by accepting that anyone can reroll anyone's dice.
- `encodeReroll` uses `URLSearchParams`, so values that would otherwise break the encoding (`&`, `=`, spaces in an annotation label) are escaped and round-trip correctly. Covered by a test using `2d6+3[fire & ice]`.
- `apps/discord-bot/CLAUDE.md` documents the codec and the type-4 rule, so the next person adding a button doesn't rediscover the ownership problem.

## Stack status

With this merged, the migration is complete: every command renders Components V2, the embed path is gone, and the interactive affordance that justified the migration works. Remaining from the plan, deliberately not attempted here: per-section thumbnails, container spoilers for hidden rolls, and custom application emoji for die faces.

**Still unverified: the Discord mobile clients.** V2 layout is server-declared so it should be consistent, but I have no way to check from this environment, and it's worth a look before this stack merges.

**This stack needs `bun run deploy-commands`** — #1243 adds four new slash-command options, and per `CLAUDE.md` registration is manual and skipping it has already caused one outage.

## Checklist

- [x] `bun run check:all` passes for the touched package; `knip` clean
- [x] Tests cover the change — 154 pass, up from 133; the codec round-trip, the limit boundary, escaping, both flag paths, and every degradation above
- [x] Bundle size limits respected (no new dependencies)
- [x] Public API changes reflected in the matching docs — `apps/discord-bot/CLAUDE.md` updated
- [x] No generated files touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF

---
_Generated by [Claude Code](https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF)_