### PR TITLE
fix(discord-bot): restore /roll's "Did you mean" suggestion, once

### DIFF
--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, test } from 'bun:test'
 import { commands as commandList } from '../../src/commands/index.js'
+import { encodeReroll } from '../../src/commands/lib/index.js'
 import { ContainerBuilder, TextDisplayBuilder } from '../../src/utils/builders.js'
 import { dispatchInteraction, InteractionResponseType } from '../../src/worker/dispatch.js'
 import type { Command, RollView } from '../../src/types.js'
@@ -97,6 +98,56 @@ describe('dispatchInteraction', () => {
   test('turns a bad roll into an error response, not a throw', () => {
     const response = invoke('roll', [{ name: 'notation', value: 'not-notation' }])
     expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
+  })
+
+  test('offers a correction when the notation is a near miss', () => {
+    // `/roll` is the one command with its own `describeError`, and the
+    // dispatcher has to prefer it over `defaultErrorMessage` or the hook never
+    // runs.
+    //
+    // Asserted on the BACKTICKED form deliberately. NotationParseError already
+    // ends with a double-quoted `Did you mean "2d6"?` of its own, so a looser
+    // check for 'Did you mean' would pass with the hook unwired — a test that
+    // proves nothing. Backticks are only ever produced by describeRollError.
+    const rendered = JSON.stringify(
+      invoke('roll', [{ name: 'notation', value: '26' }]).data?.components
+    )
+
+    expect(rendered).toContain('Did you mean `2d6`?')
+    // Exactly once. The hook strips the roller's own copy before appending;
+    // saying it twice is the defect this replaced.
+    expect(rendered.match(/Did you mean/g)).toHaveLength(1)
+  })
+
+  test('a reroll of a near miss gets the same correction', () => {
+    // The reroll path has its own catch block. It carries the original
+    // options in the custom_id, so it must answer identically rather than
+    // falling back to the bare message.
+    const customId = encodeReroll('roll', { notation: '26' })
+    // Guards the test itself: encodeReroll returns undefined when the id will
+    // not fit, and a dispatch with no custom_id would pass for the wrong
+    // reason. Thrown rather than asserted so it also narrows the type.
+    if (customId === undefined) throw new Error('encodeReroll could not encode the test id')
+
+    const response = dispatchInteraction(
+      {
+        type: 3,
+        data: { custom_id: customId },
+        member: { user: { global_name: 'Tester', username: 'tester' } }
+      },
+      commands
+    ) as Rendered
+
+    expect(JSON.stringify(response.data?.components)).toContain('Did you mean `2d6`?')
+  })
+
+  test('falls back to the plain message when nothing can be suggested', () => {
+    // The other half of the hook: no suggestion must mean no dangling "Did you
+    // mean" with an empty backtick pair after it.
+    const rendered = JSON.stringify(
+      invoke('roll', [{ name: 'notation', value: 'not-notation' }]).data?.components
+    )
+    expect(rendered).not.toContain('Did you mean `')
   })
 
   test('an error is ephemeral and carries the V2 flag', () => {

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -9,6 +9,7 @@ export { decodeReroll, encodeReroll, isRerollId } from './reroll.js'
 interface CreateGameCommandOptions {
   readonly data: Command['data']
   readonly buildView: (context: CommandContext) => RollView
+  readonly describeError?: (error: unknown, context: CommandContext) => string
 }
 
 /** Default message for the shared catch block: the error text, or a generic fallback. */
@@ -30,9 +31,11 @@ export function defaultErrorMessage(error: unknown): string {
  * a command built through this factory cannot omit its renderer.
  */
 export function createGameCommand(options: CreateGameCommandOptions): Command {
-  const { data, buildView } = options
+  const { data, buildView, describeError } = options
 
-  return { data, buildView }
+  // Spread rather than always set: `exactOptionalPropertyTypes` makes an
+  // explicit `describeError: undefined` a different type from an absent key.
+  return { data, buildView, ...(describeError ? { describeError } : {}) }
 }
 
 /** Formats a modifier with an explicit sign: positive values gain a leading `+`. */

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -1,9 +1,16 @@
 import { roll } from '@randsum/roller/roll'
 import type { TraceableRollRecord } from '@randsum/roller/trace'
+import { suggestNotationFix } from '@randsum/roller'
 import { notation as createNotation } from '@randsum/roller/validate'
 import { SlashCommandBuilder } from '../utils/builders.js'
 import { BRAND } from '../utils/palette.js'
-import { createGameCommand, encodeReroll, renderTrace, rollContainer } from './lib/index.js'
+import {
+  createGameCommand,
+  defaultErrorMessage,
+  encodeReroll,
+  renderTrace,
+  rollContainer
+} from './lib/index.js'
 import type { CommandContext } from './lib/index.js'
 import type { Command, RollView } from '../types.js'
 
@@ -133,6 +140,37 @@ function buildRollView(context: CommandContext): RollView {
   return containers
 }
 
+/**
+ * Restates a near-miss notation as "Did you mean `2d6`?" on its own line.
+ *
+ * The base message says what is wrong; this says what to type instead, which is
+ * the useful half when someone types `26` for `2d6`. Reads the option off the
+ * context rather than the error because not every error carries the notation.
+ *
+ * The strip is not cosmetic. `NotationParseError` already ends its message with
+ * a `Did you mean "2d6"?` of its own, so appending blindly says it twice — which
+ * is what the gateway bot did, since the roller gained that suffix (#1160)
+ * before anyone re-read this function. Removing the roller's copy first leaves
+ * one suggestion, on its own line, in backticks that Discord renders as code.
+ *
+ * Matched against the exact suffix the roller would have built from this same
+ * suggestion, so a message ending some other way is left alone rather than
+ * having its tail guessed at.
+ */
+function describeRollError(error: unknown, context: CommandContext): string {
+  const notationString = context.options.getString('notation', true)
+  const baseMessage = defaultErrorMessage(error)
+  const suggestion = suggestNotationFix(notationString)
+  if (!suggestion) return baseMessage
+
+  const rollerSuffix = ` Did you mean "${suggestion}"?`
+  const trimmed = baseMessage.endsWith(rollerSuffix)
+    ? baseMessage.slice(0, -rollerSuffix.length)
+    : baseMessage
+
+  return `${trimmed}\n\nDid you mean \`${suggestion}\`?`
+}
+
 export const rollCommand: Command = createGameCommand({
   data: new SlashCommandBuilder()
     .setName('roll')
@@ -149,5 +187,6 @@ export const rollCommand: Command = createGameCommand({
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-  buildView: buildRollView
+  buildView: buildRollView,
+  describeError: describeRollError
 })

--- a/apps/discord-bot/src/types.ts
+++ b/apps/discord-bot/src/types.ts
@@ -42,4 +42,13 @@ export interface Command {
    * menu inside its container.
    */
   buildView?: (context: CommandContext) => RollView
+  /**
+   * Bespoke error text for the dispatcher's catch blocks.
+   *
+   * Only `/roll` has one: an invalid notation is usually a near miss, and
+   * `suggestNotationFix` can name the correction. Optional because every other
+   * command's failure is already self-explanatory — the dispatcher falls back
+   * to `defaultErrorMessage`, so a command that omits this loses nothing.
+   */
+  describeError?: (error: unknown, context: CommandContext) => string
 }

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -164,14 +164,19 @@ function dispatchReroll(
     return errorResponse(`\`/${target.commandName}\` is no longer available.`)
   }
 
+  // Built before the try so the catch can hand it to `describeError`. A reroll
+  // carries the original invocation's options in its `custom_id`, so the hook
+  // sees the same notation the slash command did and answers identically —
+  // there is no second error wording to keep in step.
+  const context = {
+    options: target.options,
+    userDisplayName: resolveDisplayName(payload)
+  }
+
   try {
-    const view = command.buildView({
-      options: target.options,
-      userDisplayName: resolveDisplayName(payload)
-    })
-    return viewResponse(view, target.hidden)
+    return viewResponse(command.buildView(context), target.hidden)
   } catch (error) {
-    return errorResponse(defaultErrorMessage(error))
+    return errorResponse(command.describeError?.(error, context) ?? defaultErrorMessage(error))
   }
 }
 
@@ -248,13 +253,17 @@ export function dispatchInteraction(
   }
 
   const options = optionsFromPayload(payload.data?.options)
+  // Outside the try so the catch block can pass it to `describeError`, which
+  // needs the invocation's options to say anything specific about what failed.
+  const context = { options, userDisplayName: resolveDisplayName(payload) }
 
   try {
-    const context = { options, userDisplayName: resolveDisplayName(payload) }
     const hidden = options.getBoolean('hidden') ?? false
 
     return viewResponse(command.buildView(context), hidden)
   } catch (error) {
-    return errorResponse(defaultErrorMessage(error))
+    // The command gets first refusal on the wording — `/roll` uses it to
+    // suggest a correction — and `defaultErrorMessage` covers everyone else.
+    return errorResponse(command.describeError?.(error, context) ?? defaultErrorMessage(error))
   }
 }


### PR DESCRIPTION
Rebuilt on top of the Components V2 series (#1239–#1246). The original version of this change hung off `buildEmbed` and the single catch block that existed then; #1245 deleted both, so this re-applies the same behaviour to the shape that replaced them rather than resolving a conflict into a structure that no longer exists.

`Command.describeError` is back, and both dispatcher catch blocks call it:

```ts
command.describeError?.(error, context) ?? defaultErrorMessage(error)
```

**Both, not one.** `dispatchReroll` has its own catch, and a reroll carries the original invocation's options in its `custom_id` — so the hook sees the same notation the slash command did and answers identically. Wiring only the command path would have meant a near miss explained on the first attempt and bare on the retry. Each path now builds its context above its `try` rather than inside it, which is what puts it in scope for the `catch`.

`/roll` is the only user. It was removed as dead code in 59d96a8f, correctly — nothing called it after the Worker cutover, and wiring it there would have been a behaviour change inside a cleanup. This is that behaviour change, made deliberately.

## The suggestion was never actually absent

`notation()` passes `suggestNotationFix`'s result into `NotationParseError`, whose message has ended with `Did you mean "2d6"?` since #1160 — before the cutover. `defaultErrorMessage` returns that message verbatim, so a suggestion has been reaching users all along, just inline and in double quotes.

Which means appending blindly says it twice, and the gateway bot did exactly that for two months. `describeRollError` strips the roller's copy before appending its own, matched against the exact suffix the roller would have built from the same suggestion — so a message ending some other way is left alone rather than having its tail guessed at. One suggestion, on its own line, in backticks Discord renders as code:

```
Invalid notation "26": String does not match dice notation pattern.

Did you mean `2d6`?
```

Verified on both the slash-command and reroll paths.

## On the tests

They assert the backticked form specifically. A looser check for `Did you mean` passes with the hook unwired, since the roller's own message satisfies it — confirmed by reverting the dispatcher line and watching it still pass. They also count the matches, so a regression that restores the doubling fails too. Three cases: near miss via slash command, near miss via reroll button, and the no-suggestion fallback.

## Verification

- `bun run --filter '@randsum/discord-bot' check` — 172 pass, 0 fail
- `bun run knip` — clean

No changeset: `@randsum/discord-bot` is in the changesets ignore list.

Co-authored with alxjrvs.
