### PR TITLE
fix(discord-bot): hold the message character cap, and stop a 500 on long input

### DIFF
--- a/apps/discord-bot/__tests__/commands/roll.test.ts
+++ b/apps/discord-bot/__tests__/commands/roll.test.ts
@@ -247,6 +247,85 @@ describe('rollCommand', () => {
     expect(componentCountOf(view)).toBeLessThanOrEqual(40)
   })
 
+  test('a long headline and description are counted, not estimated', () => {
+    // The regression this guards. The previous guard charged a flat 160
+    // characters per container for headline, description and derivation and
+    // measured only the trace lines. A pool whose notation and description are
+    // both long costs 685 on its own, so the estimate under-counted by 4x and
+    // `4d1000R{=1..=200}x6` shipped 8416 characters into a rejected message.
+    const longNotation = `4d1000R{${Array.from({ length: 60 }, (_, index) => `=${index + 1}`).join(',')}}`
+    mockRoll.mockImplementationOnce(() => ({
+      total: 24000,
+      rolls: Array.from({ length: 6 }, () => ({
+        notation: longNotation,
+        description: [`Roll 4 1000-sided dice`, `Reroll any of [${'1, '.repeat(200)}]`],
+        total: 4000,
+        initialRolls: [1000, 1000, 1000, 1000],
+        rolls: [1000, 1000, 1000, 1000],
+        modifierLogs: [],
+        appliedTotal: 4000
+      }))
+    }))
+    const view = render(`${longNotation}x6`)
+    expect(characterCountOf(view)).toBeLessThanOrEqual(4000)
+    expect(componentCountOf(view)).toBeLessThanOrEqual(40)
+  })
+
+  test('a single pool over the budget on its own has its body clamped', () => {
+    // There is no later pool to drop, so the only lever left is the body.
+    // `1000d1000L500` measured at 4100 characters and reached the user as the
+    // dispatcher's "Something went wrong" instead of a roll.
+    mockRoll.mockImplementationOnce(() => ({
+      total: 500000,
+      rolls: [
+        {
+          notation: '1000d1000L500',
+          description: ['Roll 1000 1000-sided dice', 'Drop lowest 500'],
+          total: 500000,
+          initialRolls: Array.from({ length: 1000 }, () => 1000),
+          rolls: Array.from({ length: 500 }, () => 1000),
+          modifierLogs: [
+            {
+              modifier: 'drop',
+              options: { lowest: 500 },
+              added: [],
+              removed: Array.from({ length: 500 }, () => 1000)
+            }
+          ],
+          appliedTotal: 500000
+        }
+      ]
+    }))
+    const view = render('1000d1000L500')
+    expect(view).toHaveLength(1)
+    expect(characterCountOf(view)).toBeLessThanOrEqual(4000)
+    expect(textOf(view)).toContain('truncated')
+  })
+
+  test('a very long notation is echoed in shortened form', () => {
+    // The derivation line echoes the notation verbatim, and a 900-character
+    // reroll set is valid notation — so the echo alone claimed a quarter of the
+    // budget for a roll that was perfectly fine.
+    const long = `1d1000R{${Array.from({ length: 200 }, (_, index) => `=${index + 1}`).join(',')}}`
+    mockRoll.mockImplementationOnce(() => ({
+      total: 1503,
+      rolls: [
+        {
+          notation: '1d6',
+          description: [],
+          total: 1503,
+          initialRolls: [3],
+          rolls: [3],
+          modifierLogs: [],
+          appliedTotal: 1503
+        }
+      ]
+    }))
+    const view = render(long)
+    expect(characterCountOf(view)).toBeLessThanOrEqual(4000)
+    expect(textOf(view)).toContain('…')
+  })
+
   test('a single over-long pool is rendered rather than dropped', () => {
     // One pool is the whole answer to what the user asked; dropping it would
     // leave a container reporting a total with no dice at all.

--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -37,6 +37,25 @@ function invoke(name: string, options: { name: string; value: unknown }[] = []):
   ) as Rendered
 }
 
+function characterCountOf(components: readonly unknown[]): number {
+  const walk = (node: unknown): number => {
+    if (node === null || typeof node !== 'object') return 0
+    const own =
+      'type' in node && node.type === 10 && 'content' in node ? String(node.content).length : 0
+    return (
+      own +
+      Object.values(node).reduce<number>(
+        (total, value) =>
+          total +
+          (Array.isArray(value) ? value.reduce<number>((a, v) => a + walk(v), 0) : walk(value)),
+        0
+      )
+    )
+  }
+
+  return components.reduce<number>((total, component) => total + walk(component), 0)
+}
+
 describe('dispatchInteraction', () => {
   test('answers a PING with a PONG', () => {
     const response = dispatchInteraction({ type: 1 }, commands) as Rendered
@@ -234,6 +253,32 @@ describe('dispatchInteraction', () => {
         new Map([['probe', { data: commandList[0]!.data }]])
       ) as Rendered
       expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
+    })
+  })
+
+  describe('error rendering', () => {
+    test('an over-long error message is clamped rather than thrown', () => {
+      // The regression this guards. `roll()` reports invalid notation by
+      // quoting it back, so a 3937-character argument produced an error message
+      // past the 4000-character Text Display cap — and `setContent` throws
+      // rather than truncating. The throw escaped the dispatcher, and
+      // Cloudflare answered Discord with a 500.
+      const response = invoke('roll', [{ name: 'notation', value: 'z'.repeat(3937) }])
+      expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+      expect(JSON.stringify(response.data?.components)).toContain('Something went wrong')
+    })
+
+    test('a long valid notation renders a roll, within the character budget', () => {
+      // End to end against the real roller, no fixtures: a 900-character reroll
+      // set is valid notation, and every pool echoes it in the headline while
+      // echoing a 726-character description below it. The guard this replaced
+      // charged a flat 160 per container and let 8416 characters through.
+      const long = `4d1000R{${Array.from({ length: 200 }, (_, index) => `=${index + 1}`).join(',')}}x6`
+      const response = invoke('roll', [{ name: 'notation', value: long }])
+
+      const rendered = JSON.stringify(response.data?.components)
+      expect(rendered).not.toContain('Something went wrong')
+      expect(characterCountOf(response.data?.components ?? [])).toBeLessThanOrEqual(4000)
     })
   })
 

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -3,7 +3,13 @@ import type { CommandContext } from './context.js'
 
 export type { CommandContext } from './context.js'
 export type { ViewFact } from './view.js'
-export { renderTrace, rollContainer } from './view.js'
+export {
+  TEXT_DISPLAY_LIMIT,
+  clampContent,
+  measureContainer,
+  renderTrace,
+  rollContainer
+} from './view.js'
 export { decodeReroll, encodeReroll, isRerollId } from './reroll.js'
 
 interface CreateGameCommandOptions {

--- a/apps/discord-bot/src/commands/lib/view.ts
+++ b/apps/discord-bot/src/commands/lib/view.ts
@@ -24,6 +24,7 @@ import { traceRoll, formatAsMath } from '@randsum/roller/trace'
 import type { TraceableRollRecord } from '@randsum/roller/trace'
 import {
   ButtonBuilder,
+  ComponentType,
   ButtonStyle,
   ContainerBuilder,
   SectionBuilder,
@@ -43,12 +44,41 @@ import { CUSTOM_ID_LIMIT } from './reroll.js'
  * and a pool of four-digit faces renders past 4000 well before that. Clamping
  * here rather than at the call site means every future renderer inherits it.
  */
-const TEXT_DISPLAY_LIMIT = 4000
+export const TEXT_DISPLAY_LIMIT = 4000
 
-function clampContent(content: string): string {
-  if (content.length <= TEXT_DISPLAY_LIMIT) return content
+export function clampContent(content: string, limit: number = TEXT_DISPLAY_LIMIT): string {
+  if (content.length <= limit) return content
   const notice = '\n-# …truncated'
-  return content.slice(0, TEXT_DISPLAY_LIMIT - notice.length) + notice
+  return content.slice(0, Math.max(1, limit - notice.length)) + notice
+}
+
+/**
+ * Everything Discord counts against the ~4000-character message budget.
+ *
+ * Measured from the built container rather than estimated from its inputs: the
+ * previous guard charged a flat 160 per container for headline, facts and
+ * derivation, and a headline that echoes a long notation runs to 685 on its
+ * own. That estimate let an 8416-character message through.
+ */
+export function measureContainer(container: ContainerBuilder): number {
+  const walk = (node: unknown): number => {
+    if (node === null || typeof node !== 'object') return 0
+    const own =
+      'type' in node && node.type === ComponentType.TextDisplay && 'content' in node
+        ? String(node.content).length
+        : 0
+    return (
+      own +
+      Object.values(node).reduce<number>(
+        (sum, value) =>
+          sum +
+          (Array.isArray(value) ? value.reduce<number>((a, v) => a + walk(v), 0) : walk(value)),
+        0
+      )
+    )
+  }
+
+  return walk(container.toJSON())
 }
 
 /** A label/value pair — the replacement for an inline embed field. */
@@ -72,6 +102,13 @@ export interface RollContainerOptions {
   readonly derivation?: string
   /** Encoded reroll state. Omitted — with the button — when over the id limit. */
   readonly rerollId?: string
+  /**
+   * Clamp the body to this many characters instead of the Text Display limit.
+   *
+   * A single pool can exceed the whole-message budget on its own, and there is
+   * no later pool to drop — so the only lever left is the body itself.
+   */
+  readonly bodyBudget?: number
 }
 
 /** Joins label/value pairs into the single line that replaces the field grid. */
@@ -122,15 +159,19 @@ export function renderTrace(record: TraceableRollRecord): readonly string[] {
 export function rollContainer(options: RollContainerOptions): ContainerBuilder {
   const container = new ContainerBuilder().setAccentColor(options.accent)
 
-  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${options.headline}`))
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(clampContent(`## ${options.headline}`))
+  )
 
   if (options.consequence !== undefined && options.consequence.length > 0) {
-    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(options.consequence))
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(clampContent(options.consequence))
+    )
   }
 
   if (options.facts !== undefined && options.facts.length > 0) {
     container.addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(renderFacts(options.facts))
+      new TextDisplayBuilder().setContent(clampContent(renderFacts(options.facts)))
     )
   }
 
@@ -140,7 +181,9 @@ export function rollContainer(options: RollContainerOptions): ContainerBuilder {
       new SeparatorBuilder().setDivider(true).setSpacing(SeparatorSpacingSize.Small)
     )
 
-    const text = new TextDisplayBuilder().setContent(clampContent(body.join('\n')))
+    const text = new TextDisplayBuilder().setContent(
+      clampContent(body.join('\n'), options.bodyBudget ?? TEXT_DISPLAY_LIMIT)
+    )
     const rerollable = options.rerollId !== undefined && options.rerollId.length <= CUSTOM_ID_LIMIT
 
     if (rerollable) {
@@ -162,7 +205,9 @@ export function rollContainer(options: RollContainerOptions): ContainerBuilder {
       ? `${options.derivation} · ${FOOTER_ATTRIBUTION}`
       : FOOTER_ATTRIBUTION
 
-  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${derivation}`))
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(clampContent(`-# ${derivation}`))
+  )
 
   return container
 }

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -1,9 +1,15 @@
 import { roll } from '@randsum/roller/roll'
-import type { TraceableRollRecord } from '@randsum/roller/trace'
 import { notation as createNotation } from '@randsum/roller/validate'
 import { SlashCommandBuilder } from '../utils/builders.js'
 import { BRAND } from '../utils/palette.js'
-import { createGameCommand, encodeReroll, renderTrace, rollContainer } from './lib/index.js'
+import {
+  TEXT_DISPLAY_LIMIT,
+  createGameCommand,
+  encodeReroll,
+  measureContainer,
+  renderTrace,
+  rollContainer
+} from './lib/index.js'
 import type { CommandContext } from './lib/index.js'
 import type { Command, RollView } from '../types.js'
 
@@ -37,6 +43,27 @@ const MAX_POOLS = 5
 const MAX_CHARACTERS = 4000
 
 /**
+ * How much of the notation the headline and derivation echo back.
+ *
+ * The notation is already on screen in the user's own command, so echoing all
+ * of it buys nothing — and `roll()` accepts notation far longer than a whole
+ * message may be. `1d6+1d6+…` repeated a few hundred times parses fine and
+ * produced a derivation line that alone blew the budget, which is how a valid
+ * roll reached the user as "Something went wrong".
+ */
+const NOTATION_ECHO_LIMIT = 200
+
+/** Shortens a value for inline display, with an ellipsis rather than a notice. */
+function truncateInline(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`
+}
+
+/** Everything the rendered view spends against the message character budget. */
+function measureView(view: RollView): number {
+  return view.reduce<number>((total, container) => total + measureContainer(container), 0)
+}
+
+/**
  * `/roll` — the generic notation roller, and the bot's flagship command.
  *
  * Note that the command takes a *single* notation string, so several pools can
@@ -48,89 +75,87 @@ const MAX_CHARACTERS = 4000
  * the body is `traceRoll` output rather than two parallel plain lists, so a
  * dropped or rerolled die is marked in place instead of the reader diffing
  * "Initial Rolls" against "Modified Rolls" by eye.
- */
-/**
- * Drop trailing pools until the rendered dice fit the character budget.
  *
- * Counts only what this view actually renders — the trace lines — plus a fixed
- * allowance for the headline, description and derivation each container adds.
- * A single pool is never dropped: one over-long pool is still the answer to
- * what the user asked, and `rollContainer` is the wrong place to silently
- * discard it.
+ * Fitting the character budget is done by **building and measuring**, not by
+ * estimating. The estimate this replaces charged a flat 160 characters per
+ * container for headline, description and derivation; the real figure reaches
+ * 685 when the headline echoes a long pool notation and the consequence echoes
+ * a long description, and `4d1000R{=1..=200}x6` shipped 8416 characters — more
+ * than twice the cap — straight into a rejected message.
  */
-function fitPools<T extends TraceableRollRecord>(
-  pools: readonly T[],
-  multiple: boolean
-): readonly T[] {
-  const PER_CONTAINER_OVERHEAD = 160
-  const budget = MAX_CHARACTERS - (multiple ? PER_CONTAINER_OVERHEAD : 0)
-
-  // `stopped` rather than filtering: once a pool does not fit, every later pool
-  // is dropped too. Skipping one and keeping the next would renumber
-  // "Pool 3 of 6" against pools the reader never saw.
-  return pools.reduce<{
-    readonly fitted: readonly T[]
-    readonly used: number
-    readonly stopped: boolean
-  }>(
-    (accumulator, record) => {
-      if (accumulator.stopped) return accumulator
-
-      const cost = renderTrace(record).join('\n').length + PER_CONTAINER_OVERHEAD
-      const fits = accumulator.fitted.length === 0 || accumulator.used + cost <= budget
-
-      return fits
-        ? { fitted: [...accumulator.fitted, record], used: accumulator.used + cost, stopped: false }
-        : { ...accumulator, stopped: true }
-    },
-    { fitted: [], used: 0, stopped: false }
-  ).fitted
-}
-
 function buildRollView(context: CommandContext): RollView {
   const notationString = context.options.getString('notation', true)
   const validNotation = createNotation(notationString)
   const result = roll(validNotation)
 
   const multiple = result.rolls.length > 1
-  const pools = fitPools(result.rolls.slice(0, MAX_POOLS), multiple)
+  const capped = result.rolls.slice(0, MAX_POOLS)
+  const notationEcho = truncateInline(notationString, NOTATION_ECHO_LIMIT)
 
   // The whole roll re-rolls, not one pool, so the button belongs on the first
   // container only. Long notation simply gets no button — see `encodeReroll`.
   const hidden = context.options.getBoolean('hidden') ?? false
   const rerollId = encodeReroll('roll', { notation: notationString, hidden })
 
-  const containers = pools.map((record, index) => {
-    const description = (record.description ?? []).join(' · ')
+  const render = (count: number, bodyBudget?: number): RollView => {
+    const pools = capped.slice(0, count)
 
-    return rollContainer({
-      accent: BRAND,
-      // A single pool leads with the number, because that is the answer. Several
-      // pools lead with which pool this is, and the grand total gets its own
-      // line below.
-      headline: multiple ? `${record.notation}  ·  ${record.total}` : String(result.total),
-      ...(description.length > 0 ? { consequence: description } : {}),
-      body: renderTrace(record),
-      derivation: multiple ? `Pool ${index + 1} of ${result.rolls.length}` : notationString,
-      ...(index === 0 && rerollId !== undefined ? { rerollId } : {})
+    const containers = pools.map((record, index) => {
+      const description = truncateInline(
+        (record.description ?? []).join(' · '),
+        NOTATION_ECHO_LIMIT
+      )
+
+      return rollContainer({
+        accent: BRAND,
+        // A single pool leads with the number, because that is the answer. Several
+        // pools lead with which pool this is, and the grand total gets its own
+        // line below.
+        headline: multiple
+          ? `${truncateInline(record.notation, NOTATION_ECHO_LIMIT)}  ·  ${record.total}`
+          : String(result.total),
+        ...(description.length > 0 ? { consequence: description } : {}),
+        body: renderTrace(record),
+        derivation: multiple ? `Pool ${index + 1} of ${result.rolls.length}` : notationEcho,
+        ...(index === 0 && rerollId !== undefined ? { rerollId } : {}),
+        ...(bodyBudget !== undefined ? { bodyBudget } : {})
+      })
     })
-  })
 
-  if (multiple) {
+    if (!multiple) return containers
+
     const omitted = result.rolls.length - pools.length
-    containers.push(
+    return [
+      ...containers,
       rollContainer({
         accent: BRAND,
         headline: `Total  ${result.total}`,
         ...(omitted > 0
           ? { consequence: `${omitted} further pool${omitted === 1 ? '' : 's'} not shown.` }
           : {}),
-        derivation: notationString
+        derivation: notationEcho
       })
-    )
+    ]
   }
 
-  return containers
+  // Widest view first: keep every pool that fits, drop trailing pools until one
+  // does. Dropping from the end rather than skipping a single fat pool keeps
+  // "Pool 3 of 6" honest — a reader never sees a gap in the numbering.
+  const fitted = Array.from({ length: capped.length }, (_, index) => capped.length - index)
+    .map(count => render(count))
+    .find(view => measureView(view) <= MAX_CHARACTERS)
+
+  if (fitted !== undefined) return fitted
+
+  // A single pool is never dropped: one over-long pool is still the answer to
+  // what the user asked. The only lever left is its body, so give it whatever
+  // the headline, consequence and derivation are not already using.
+  const single = render(1)
+  const first = capped[0]
+  const bodyLength = first === undefined ? 0 : renderTrace(first).join('\n').length
+  const overhead = measureView(single) - Math.min(bodyLength, TEXT_DISPLAY_LIMIT)
+
+  return render(1, Math.max(1, MAX_CHARACTERS - overhead))
 }
 
 export const rollCommand: Command = createGameCommand({

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -12,7 +12,13 @@
  * alive, no second failure mode) and visibly faster — the user never sees a
  * "thinking…" state for work that was already done.
  */
-import { ContainerBuilder, MessageFlags, TextDisplayBuilder } from '../utils/builders.js'
+import {
+  ComponentType,
+  ContainerBuilder,
+  MessageFlags,
+  TextDisplayBuilder
+} from '../utils/builders.js'
+import { clampContent } from '../commands/lib/view.js'
 import { FOOTER_ATTRIBUTION } from '../utils/constants.js'
 import { ERROR } from '../utils/palette.js'
 import { optionsFromPayload } from '../commands/lib/context.js'
@@ -34,6 +40,11 @@ import type { Command, RollView } from '../types.js'
  * silently miss it.
  */
 const NO_MENTIONS = { parse: [] as const }
+
+/**
+ * Room for the heading and footer that share the error container's budget.
+ */
+const ERROR_MESSAGE_LIMIT = 3500
 
 /** Discord's interaction type numbers. */
 export const InteractionType = {
@@ -107,6 +118,37 @@ function viewResponse(view: RollView, hidden: boolean): unknown {
 }
 
 /**
+ * The last resort, built from plain object literals rather than builders.
+ *
+ * Nothing here can validate and therefore nothing here can throw, which is the
+ * whole point: it is what `worker/index.ts` falls back to when building a real
+ * response failed.
+ */
+export function fallbackErrorResponse(): unknown {
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+      allowed_mentions: NO_MENTIONS,
+      components: [
+        {
+          type: ComponentType.Container,
+          accent_color: ERROR,
+          components: [
+            { type: ComponentType.TextDisplay, content: '## Something went wrong' },
+            {
+              type: ComponentType.TextDisplay,
+              content: 'That request could not be rendered. Try a shorter notation.'
+            },
+            { type: ComponentType.TextDisplay, content: `-# ${FOOTER_ATTRIBUTION}` }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+/**
  * The error surface, as a container like everything else.
  *
  * Two things were wrong with the embed version beyond its shape. Its `0xff0000`
@@ -129,7 +171,13 @@ function errorResponse(message: string): unknown {
           .setAccentColor(ERROR)
           .addTextDisplayComponents(
             new TextDisplayBuilder().setContent('## Something went wrong'),
-            new TextDisplayBuilder().setContent(message),
+            // Clamped, because this is the one Text Display whose content is
+            // not ours: a validator message quotes the user's input back, and
+            // `/roll notation:<3937 chars>` made `setContent` throw INSIDE the
+            // catch block — escaping the dispatcher entirely and turning a bad
+            // roll into a Cloudflare 500. The `notation` option declares no
+            // max_length, so Discord accepts up to 6000 characters.
+            new TextDisplayBuilder().setContent(clampContent(message, ERROR_MESSAGE_LIMIT)),
             new TextDisplayBuilder().setContent(`-# ${FOOTER_ATTRIBUTION}`)
           )
           .toJSON()

--- a/apps/discord-bot/src/worker/index.ts
+++ b/apps/discord-bot/src/worker/index.ts
@@ -15,7 +15,7 @@
  */
 import { commands as commandList } from '../commands/index.js'
 import type { Command } from '../types.js'
-import { dispatchInteraction } from './dispatch.js'
+import { dispatchInteraction, fallbackErrorResponse } from './dispatch.js'
 import { verifyDiscordRequest } from './verify.js'
 
 export interface Env {
@@ -61,7 +61,24 @@ export default {
       return new Response('Malformed payload', { status: 400 })
     }
 
-    const response = dispatchInteraction(payload as never, commands)
+    // Belt and braces around a pure function. `dispatchInteraction` catches
+    // renderer throws and turns them into an error response — but the error
+    // response is itself built with validating builders, so a throw while
+    // BUILDING it escapes the catch. That happened: a 3937-character notation
+    // made the error container's own `setContent` throw, and with nothing here
+    // the promise rejected and Cloudflare returned 500. The user sees "This
+    // interaction failed" and Discord retries, which fails identically.
+    //
+    // The specific bug is fixed at its source; this is here so the next one
+    // costs a wrong-looking message rather than a dead endpoint.
+    const response = ((): unknown => {
+      try {
+        return dispatchInteraction(payload as never, commands)
+      } catch {
+        return fallbackErrorResponse()
+      }
+    })()
+
     if (response === undefined) {
       return new Response('Unsupported interaction type', { status: 400 })
     }


### PR DESCRIPTION
## Summary

Two defects found by an adversarial re-review of the Components V2 migration. Both are live on `main`, deployed, and reachable by typing into Discord — a `/roll` with a long notation either gets rejected by Discord as an over-long message or takes the endpoint down with a Cloudflare 500.

### 1. `/roll` breached the 4000-character cap by up to 2×

`fitPools` estimated a container's cost as its trace lines plus a **flat 160** for headline, description and derivation. The real figure reaches **685** the moment the headline echoes the pool's `notation` and the consequence echoes its `description` — both of which the V2 renderer added and the estimate never learned about.

Measured against `main`:

| notation | rendered | cap |
| --- | --- | --- |
| `4d1000R{…}x6` | 8416 | 4000 |
| `1000d1000L500` | 4100 | 4000 |
| `1000d1000L` | 4093 | 4000 |

Discord rejects the message outright, so the user sees "This interaction failed".

The estimate is replaced by **building the view and measuring it**: render the widest, drop trailing pools until one fits. A single pool is still never dropped — one over-long pool is the answer to what was asked — so it instead gets a `bodyBudget` of whatever the rest of the container is not using. The notation echoed into headlines and derivations is capped at 200 characters, because a valid reroll set runs to 900 and the echo alone claimed a quarter of the budget for a roll that was perfectly fine.

### 2. `/roll notation:<3937 chars>` returned a Cloudflare 500

A regression from moving the error path off raw object literals onto validating builders. `setContent` throws rather than truncating, the validator's message quotes the user's input back, and the throw happened **inside the catch block** — escaping the dispatcher entirely, so the promise rejected and Cloudflare answered Discord with a 500. The `notation` option declares no `max_length`, so Discord accepts up to 6000 characters.

The message is now clamped, and `worker/index.ts` falls back to a response built from plain object literals — nothing that can validate, so nothing that can throw — if building a real one ever fails again. Every `setContent` in `rollContainer` is clamped for the same reason: the body already was, the headline, consequence, facts and derivation were not.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games`
- [ ] `@randsum/cli`
- [x] `apps/site`, `apps/rdn`, `apps/discord-bot` — **`apps/discord-bot` only**
- [ ] Infra / CI / tooling

## Checklist

- [x] `bun run check:all` passes locally — verified under **bun 1.4.0**, matching `.bun-version`, not the sandbox default
- [x] Tests cover the change — four regression tests, each **verified to fail against the previous renderer** and pass against this one
- [x] Bundle size limits respected — no publishable package changed
- [x] Public API changes are reflected in the matching README / `apps/site` MDX — none
- [x] Game-package changes regenerate via `bun run --filter @randsum/games gen` — no game packages touched

Full pre-push chain green: build, codegen check, conformance check, test (177 pass), audit, SCA, knip, arch check.

## Verification

End to end through `dispatchInteraction` against the real command barrel and the real roller:

```
1000d1000Lx6      chars 4000 ok   components  12 ok
1000d1000R{=1}x6  chars 4000 ok   components  12 ok
1000d1000L500     chars 4000 ok   components   8 ok
1000d1000L        chars 4000 ok   components   8 ok
4d6Lx6            chars  898 ok   components  36 ok
300d100x8         chars 3997 ok   components  30 ok
3937-char invalid notation -> renders an error, no throw
```

## Merged with #1247

`main` advanced under this branch with #1247 ("Did you mean" suggestion), which touched four of the same files. The conflict was import-only in `roll.ts` — this branch drops `TraceableRollRecord`, #1247 adds `suggestNotationFix`; both import lists are unioned. `dispatch.ts` and `dispatch.test.ts` auto-merged.

The two compose correctly and were re-verified on the merged tree: #1247's `describeError` makes the error message *longer* (it appends a suggestion), which now flows through the same `clampContent` guard.

```
3937 invalid    ok, 3555 chars      big repeat      ok, 3188 chars
6000 invalid    ok, 3555 chars      1000d1000L500   ok, 4000 chars
near-miss (26)  ok,  143 chars   <- #1247's suggestion still renders
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xd2vWKgvZjV9pAdCx2qsF