### PR TITLE
build: pin node 24 so arch:check can run

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+# Node for this repo. Nothing here runs on node in production — every package
+# targets bun — but two dev tools shell out to it, and one of them is picky.
+#
+# `bun run arch:check` runs dependency-cruiser, which refuses to start on a node
+# version outside `^22||^24||>=26`. It follows node's release cycle and does not
+# accept odd-numbered releases while they are current, so a machine sitting on
+# node 25 fails the check — and because arch:check is a lefthook pre-push step,
+# that machine cannot push at all. The failure names the version, but nothing in
+# the repo previously said which one to use.
+#
+# 24 is the active LTS and matches what CI resolves to: `.github/actions/bun-setup`
+# only invokes actions/setup-node when a job passes an explicit version, so the
+# arch job runs on the runner's built-in node rather than anything pinned here.
+[tools]
+node = "24"


### PR DESCRIPTION
`bun run arch:check` runs dependency-cruiser, which refuses to start on a node version outside `^22||^24||>=26` — it follows node's release cycle and won't accept an odd-numbered release while it is still current. A machine on node 25 fails the check, and since `arch:check` is a lefthook **pre-push** step, that machine cannot push at all:

```
ERROR: Your node version (25.9.0) is not supported. dependency-cruiser
       follows the node.js release cycle and runs on these node versions:
       ^22||^24||>=26
```

The error names the constraint, but nothing in the repo said which version to use — the repo had no node version file of any kind, so the workaround was knowing the answer and setting `PATH` by hand on every push.

## Why `mise.toml` and not `.node-version`

`.node-version` does not work here. mise only reads idiomatic version files when `idiomatic_version_file_enable_tools` opts the tool in, which it doesn't by default. Verified on the machine that hit this:

| file | `mise current node` |
| --- | --- |
| `.node-version` containing `24` | `25.9.0` — ignored |
| `mise.toml` with `[tools] node = "24"` | `24.18.0` |

With the pin in place, a login shell inside the repo resolves `node` to 24.18.0 through the mise shims — which is how lefthook's hooks resolve it too — and `arch:check` passes.

## CI is unaffected

`.github/actions/bun-setup` invokes `actions/setup-node` only when a job passes an explicit version. The `arch` job passes none, so it runs on the runner's built-in node and never consulted a version file. Nothing about CI changes.

## Caveat

This fixes shells that resolve node through the mise shims. A shell whose `PATH` already has a specific `mise/installs/node/<version>/bin` directory ahead of the shims keeps that version regardless — the pin can't reorder someone's `PATH`. A fresh shell picks it up.

Co-authored with alxjrvs.
