### PR TITLE
feat(discord-bot): drop "Rolled" from the Daggerheart headline

### DIFF
--- a/apps/discord-bot/__tests__/commands/dh.test.ts
+++ b/apps/discord-bot/__tests__/commands/dh.test.ts
@@ -46,7 +46,7 @@ describe('dhCommand', () => {
     // "Critical Hope!" is not a Daggerheart term, and the consequence — you
     // gain a Hope, the GM gains a Fear — was stated nowhere in the old embed.
     const view = render()
-    expect(textOf(view)).toContain('Rolled 15 with Hope')
+    expect(textOf(view)).toContain('## ◆ 15 with Hope')
     expect(textOf(view)).toContain('You gain a Hope.')
     expect(accentsOf(view)[0]).toBe(DAGGERHEART.hope)
   })
@@ -58,7 +58,7 @@ describe('dhCommand', () => {
       details: { ...withHope().details, hope: { roll: 4, amplified: false } }
     }))
     const view = render()
-    expect(textOf(view)).toContain('Rolled 15 with Fear')
+    expect(textOf(view)).toContain('## ◈ 15 with Fear')
     expect(textOf(view)).toContain('The GM gains a Fear.')
     expect(accentsOf(view)[0]).toBe(DAGGERHEART.fear)
   })
@@ -106,10 +106,11 @@ describe('dhCommand', () => {
   })
 
   test('the headline carries the total, with or without a difficulty', () => {
-    // "Rolled 19 with Hope" — the number the table is waiting for belongs in
+    // "19 with Hope" — the number the table is waiting for belongs in
     // the headline, not buried in the facts below it.
     mockRoll.mockImplementationOnce(() => ({ ...withHope(), total: 19 }))
-    expect(textOf(render())).toContain('## ◆ Rolled 19 with Hope')
+    expect(textOf(render())).toContain('## ◆ 19 with Hope')
+    expect(textOf(render())).not.toContain('Rolled')
 
     mockRoll.mockImplementationOnce(() => ({ ...withHope(), result: 'critical_hope', total: 24 }))
     expect(textOf(render())).toContain('## ✸ Critical Success!  ·  24')

--- a/apps/discord-bot/__tests__/commands/dh.test.ts
+++ b/apps/discord-bot/__tests__/commands/dh.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 })
 
 describe('dhCommand', () => {
-  test("uses the game's own vocabulary, and states the consequence", () => {
+  test("leads with the total in the game's own vocabulary, and states the consequence", () => {
     // "Critical Hope!" is not a Daggerheart term, and the consequence — you
     // gain a Hope, the GM gains a Fear — was stated nowhere in the old embed.
     const view = render()

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -21,9 +21,10 @@ import type { Command, RollView } from '../types.js'
  * Hope/Fear axis alone.
  *
  * The old copy was also not the game's. "Critical Hope!" is not a Daggerheart
- * term; the game says Critical Success, Rolled with Hope, Rolled with Fear. And
- * the consequence — you gain a Hope, the GM gains a Fear, a crit also clears a
- * Stress — was stated nowhere.
+ * term; the game's outcomes are Critical Success, with Hope, and with Fear, and
+ * the headline leads with the total ("17 with Fear"). And the consequence — you
+ * gain a Hope, the GM gains a Fear, a crit also clears a Stress — was stated
+ * nowhere.
  */
 function buildDhView(context: CommandContext): RollView {
   const modifier = context.options.getInteger('modifier') ?? 0

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -47,15 +47,16 @@ function buildDhView(context: CommandContext): RollView {
   const accent = isCritical ? DAGGERHEART.critical : withHope ? DAGGERHEART.hope : DAGGERHEART.fear
 
   // The total is the number the table is waiting for, so every headline
-  // carries it — "Rolled 19 with Hope", not "Rolled with Hope" with the 19
-  // buried in the facts below.
+  // leads with it — "19 with Hope", not "Rolled with Hope" with the 19 buried
+  // in the facts below. No "Rolled": the glyph and the container already say
+  // this is a roll, and the number reads faster without a verb in front of it.
   const headline = ((): string => {
     // A critical succeeds regardless of Difficulty, so it never shows a DC
     // comparison — "Critical Success!  ·  6 vs DC 14" would read as a failure.
     if (isCritical) return `${GLYPH.critical} Critical Success!  ·  ${result.total}`
     const duality = withHope ? 'with Hope' : 'with Fear'
     if (difficulty === null) {
-      return `${withHope ? GLYPH.success : GLYPH.mixed} Rolled ${result.total} ${duality}`
+      return `${withHope ? GLYPH.success : GLYPH.mixed} ${result.total} ${duality}`
     }
     const succeeded = result.total >= difficulty
     const glyph = succeeded ? GLYPH.success : GLYPH.failure


### PR DESCRIPTION
## Summary

The `/dh` headline without a Difficulty now reads "◆ 17 with Hope" / "◈ 17 with Fear" instead of "◆ Rolled 17 with Hope". The glyph and the container already say this is a roll, and the number reads faster without a verb in front of it. Follow-up to #1252; the critical and success/failure headlines are unchanged.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, output shape, or semantics)
- [ ] Docs / chore / refactor (no runtime change)

## Affected packages

- [ ] `@randsum/roller`
- [ ] `@randsum/games` (and which subpath: blades / daggerheart / fifth / pbta / root-rpg / salvageunion / other)
- [x] `apps/site`, `apps/rdn`, `apps/discord-bot` — `apps/discord-bot` only
- [ ] Infra / CI / tooling

## Checklist

- [x] `bun run check:all` passes locally (build, typecheck, Biome, knip, arch, codegen, conformance, tests)
- [x] Tests cover the change — headline assertions updated to the new copy, plus an assertion that "Rolled" no longer appears
- [x] Bundle size limits respected (no publishable package changed)
- [x] Public API changes are reflected in the matching README / `apps/site` MDX (none — bot copy only)
- [x] Game-package changes regenerate via `bun run --filter @randsum/games gen` (no game-package changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143shxdybdkxCQhK9mkJ4CQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0143shxdybdkxCQhK9mkJ4CQ)_